### PR TITLE
Support getting auhenticated username

### DIFF
--- a/cdap-sentry/cdap-sentry-binding/pom.xml
+++ b/cdap-sentry/cdap-sentry-binding/pom.xml
@@ -36,10 +36,6 @@
       <artifactId>cdap-security</artifactId>
     </dependency>
     <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-common</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.sentry</groupId>
       <artifactId>sentry-provider-db</artifactId>
     </dependency>

--- a/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizer.java
+++ b/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizer.java
@@ -48,12 +48,9 @@ public class SentryAuthorizer implements Authorizer {
 
     String serviceInstanceName = cConf.get(AuthConf.SERVICE_INSTANCE_NAME,
                                            AuthConf.AuthzConfVars.getDefault(AuthConf.SERVICE_INSTANCE_NAME));
-    String requestorName = cConf.get(AuthConf.SERVICE_USER_NAME,
-                                     AuthConf.AuthzConfVars.getDefault(AuthConf.SERVICE_USER_NAME));
-
-    LOG.info("Configuring SentryAuthorizer with sentry-site.xml at {} requestor name {} and cdap instance name {}" +
-               sentrySiteUrl, requestorName, serviceInstanceName);
-    binding = new AuthBinding(sentrySiteUrl, serviceInstanceName, requestorName);
+    LOG.info("Configuring SentryAuthorizer with sentry-site.xml at {} and cdap instance name {}" +
+               sentrySiteUrl, serviceInstanceName);
+    binding = new AuthBinding(sentrySiteUrl, serviceInstanceName);
   }
 
   @Override

--- a/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/conf/AuthConf.java
+++ b/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/conf/AuthConf.java
@@ -49,9 +49,9 @@ public class AuthConf extends Configuration {
     AUTHZ_POLICY_ENGINE("sentry.cdap.policy.engine", SimplePolicyEngine.class.getName()),
     AUTHZ_PROVIDER_RESOURCE("sentry.cdap.provider.resource", ""),
     // if no instanceName or username is provided 'cdap' will be used
-    AUTHZ_INSTANCE_NAME(SERVICE_INSTANCE_NAME, "cdap"),
+    AUTHZ_SERVICE_INSTANCE_NAME(SERVICE_INSTANCE_NAME, "cdap"),
     AUTHZ_SERVICE_USER_NAME(SERVICE_USER_NAME, "cdap"),
-    AUTHZ_ADMINISTRATORS(SERVICE_SUPERUSERS, "");
+    AUTHZ_SERVICE_SUPERUSERS(SERVICE_SUPERUSERS, "");
 
     private final String varName;
     private final String defaultVal;

--- a/cdap-sentry/pom.xml
+++ b/cdap-sentry/pom.xml
@@ -86,12 +86,6 @@
     <dependencies>
       <dependency>
         <groupId>co.cask.cdap</groupId>
-        <artifactId>cdap-common</artifactId>
-        <version>${cdap.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>co.cask.cdap</groupId>
         <artifactId>cdap-security</artifactId>
         <version>${cdap.version}</version>
         <scope>provided</scope>


### PR DESCRIPTION
- Add support for getting the cdap authenticated user who is making the request.
- Currently to support testing on insecure cdap we giving a dummy username if no authenticated user is found. We will remove this toward the end of the integration: Opened an issue to track this: https://github.com/caskdata/cdap-security-extn/issues/15
