### PR TITLE
Feature/move dataset extn

### DIFF
--- a/cdap-authorization-dataset-extn/pom.xml
+++ b/cdap-authorization-dataset-extn/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright © 2015-2016 Cask Data, Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  use this file except in compliance with the License. You may obtain a copy of
+  the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>cdap</artifactId>
+    <groupId>co.cask.cdap</groupId>
+    <version>3.4.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>cdap-authorization-dataset-plugin</artifactId>
+  <name>CDAP Authorization Dataset Plugin</name>
+
+  <properties>
+    <security.authorizer.class>co.cask.cdap.security.authorization.DatasetBasedAuthorizer</security.authorizer.class>
+    <slf4j.version>1.7.5</slf4j.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-security-spi</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-api-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-security-spi</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-security</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-data-fabric</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-app-fabric</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.3.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>${security.authorizer.class}</mainClass>
+            </manifest>
+          </archive>
+          <instructions>
+            <Embed-Dependency>*;inline=false;scope=compile</Embed-Dependency>
+            <Embed-Transitive>true</Embed-Transitive>
+            <Embed-Directory>lib</Embed-Directory>
+          </instructions>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>bundle</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/cdap-authorization-dataset-extn/src/main/java/co/cask/cdap/security/authorization/ACLDataset.java
+++ b/cdap-authorization-dataset-extn/src/main/java/co/cask/cdap/security/authorization/ACLDataset.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.common.Bytes;
+import co.cask.cdap.api.dataset.lib.AbstractDataset;
+import co.cask.cdap.api.dataset.table.Row;
+import co.cask.cdap.api.dataset.table.Scanner;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * System dataset for storing ACLs for authorization.
+ *
+ * Key format:
+ * [entity][principal-type][principal-name][action].
+ *
+ * E.g.
+ * [NAMESPACE:myspace][ROLE][admins][READ]
+ */
+class ACLDataset extends AbstractDataset {
+
+  static final String TABLE_NAME = "acls";
+  private static final byte[] VALUE_COLUMN = new byte[0];
+
+  private final Table table;
+
+  ACLDataset(Table table) {
+    super(TABLE_NAME, table);
+    this.table = table;
+  }
+
+  /**
+   * Search the dataset to retrieve the set of allowed {@link Action} for the given {@link EntityId} and
+   * {@link Principal}.
+   *
+   * @param entity the entity
+   * @param principal the principal
+   * @return the set of actions allowed for the user on the entity
+   */
+  public Set<Action> search(EntityId entity, Principal principal) {
+    Set<Action> result = new HashSet<>();
+
+    ACLDatasetKey mdsKey = getKey(entity, principal);
+    byte[] startKey = mdsKey.getKey();
+    byte[] stopKey = Bytes.stopKeyForPrefix(startKey);
+    Scanner scan = table.scan(startKey, stopKey);
+
+    try {
+      Row next;
+      while ((next = scan.next()) != null) {
+        byte[] value = next.get(VALUE_COLUMN);
+        if (value == null) {
+          continue;
+        }
+        result.add(Action.valueOf(Bytes.toString(value)));
+      }
+    } finally {
+      scan.close();
+    }
+
+    return result;
+  }
+
+  /**
+   * Add an {@link Action} on the specified {@link EntityId} for the given {@link Principal}.
+   */
+  public void add(EntityId entity, Principal principal, Action action) {
+    table.put(getKey(entity, principal, action).getKey(), VALUE_COLUMN, Bytes.toBytes(action.name()));
+  }
+
+  /**
+   * Remove an {@link Action} on the specified {@link EntityId} from the given {@link Principal}.
+   */
+  public void remove(EntityId entity, Principal principal, Action action) {
+    table.delete(getKey(entity, principal, action).getKey());
+  }
+
+  /**
+   * Remove all {@link Action actions} on the specified {@link EntityId} for the given {@link Principal}.
+   */
+  public void remove(EntityId entity, Principal principal) {
+    ACLDatasetKey aclDatasetKey = getKey(entity, principal);
+    byte[] startKey = aclDatasetKey.getKey();
+    byte[] stopKey = Bytes.stopKeyForPrefix(startKey);
+    Scanner scan = table.scan(startKey, stopKey);
+
+    try {
+      Row next;
+      while ((next = scan.next()) != null) {
+        table.delete(next.getRow());
+      }
+    } finally {
+      scan.close();
+    }
+  }
+
+  /**
+   * Remove all {@link Action actions} for all {@link Principal principals} on the specified {@link EntityId}.
+   */
+  public void remove(EntityId entity) {
+    ACLDatasetKey aclDatasetKey = getKey(entity);
+    byte[] startKey = aclDatasetKey.getKey();
+    byte[] stopKey = Bytes.stopKeyForPrefix(startKey);
+    Scanner scan = table.scan(startKey, stopKey);
+
+    try {
+      Row next;
+      while ((next = scan.next()) != null) {
+        table.delete(next.getRow());
+      }
+    } finally {
+      scan.close();
+    }
+  }
+
+  /**
+   * List all the {@link Privilege privileges} for the specified {@link Principal}.
+   */
+  public Set<Privilege> listPrivileges(Principal principal) {
+    Set<Privilege> privileges = new HashSet<>();
+    // scan the whole table
+    Scanner scan = table.scan(null, null);
+    try {
+      Row next;
+      while ((next = scan.next()) != null) {
+        Principal curPrincipal = getPrincipal(next.getRow());
+        if (curPrincipal.equals(principal)) {
+          byte[] value = next.get(VALUE_COLUMN);
+          if (value == null) {
+            continue;
+          }
+          privileges.add(new Privilege(getEntity(next.getRow()), Action.valueOf(Bytes.toString(value))));
+        }
+      }
+    } finally {
+      scan.close();
+    }
+    return privileges;
+  }
+
+  private ACLDatasetKey getKey(EntityId entity) {
+    return getKeyBuilder(entity).build();
+  }
+
+  private ACLDatasetKey getKey(EntityId entity, Principal principal) {
+    return getKeyBuilder(entity, principal).build();
+  }
+
+  private ACLDatasetKey getKey(EntityId entity, Principal principal, Action action) {
+    return getKeyBuilder(entity, principal, action).build();
+  }
+
+  private ACLDatasetKey.Builder getKeyBuilder(EntityId entity, Principal principal, Action action) {
+    return getKeyBuilder(entity, principal).add(action.name());
+  }
+
+  private ACLDatasetKey.Builder getKeyBuilder(EntityId entity, Principal principal) {
+    return getKeyBuilder(entity).add(principal.getType().name()).add(principal.getName());
+  }
+
+  private ACLDatasetKey.Builder getKeyBuilder(EntityId entity) {
+    return new ACLDatasetKey.Builder().add(entity.toString());
+  }
+
+  private EntityId getEntity(byte[] rowKey) {
+    ACLDatasetKey.Splitter keySplitter = new ACLDatasetKey(rowKey).split();
+    // The rowkey is [entity][principal-type][principal-name][action-name]
+    return EntityId.fromString(keySplitter.getString());
+  }
+
+  private Principal getPrincipal(byte[] rowKey) {
+    ACLDatasetKey.Splitter keySplitter = new ACLDatasetKey(rowKey).split();
+    // The rowkey is [entity][principal-type][principal-name][action-name]
+    keySplitter.skipString(); // skip the entity
+    String principalType = keySplitter.getString();
+    String principalName = keySplitter.getString();
+    return new Principal(principalName, Principal.PrincipalType.valueOf(principalType.toUpperCase()));
+  }
+}

--- a/cdap-authorization-dataset-extn/src/main/java/co/cask/cdap/security/authorization/ACLDatasetKey.java
+++ b/cdap-authorization-dataset-extn/src/main/java/co/cask/cdap/security/authorization/ACLDatasetKey.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright © 2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.common.Bytes;
+
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+
+/**
+ * Class to generate and manage keys for {@link ACLDataset}.
+ */
+final class ACLDatasetKey {
+  private final byte[] key;
+
+  /**
+   * @param key bytearray as constructed by {@link Builder}
+   */
+  public ACLDatasetKey(byte[] key) {
+    this.key = key;
+  }
+
+  /**
+   * @return the underlying key
+   */
+  public byte[] getKey() {
+    return key;
+  }
+
+  /**
+   * Splits the keys into a {@link Splitter} which exposes the parts that comprise the key.
+   */
+  public Splitter split() {
+    return new Splitter(key);
+  }
+
+  /**
+   * Decodes the keys parts, as specified (int, long, byte[], String)
+   */
+  public static final class Splitter {
+    private final ByteBuffer byteBuffer;
+    private Splitter(byte[] bytes) {
+      byteBuffer = ByteBuffer.wrap(bytes);
+    }
+
+    /**
+     * Returns the next {@link String} part in the {@link Splitter}.
+     *
+     * @throws BufferUnderflowException if there is no String as expected
+     * @return the next String part in the splitter
+     */
+    public String getString() {
+      return Bytes.toString(getBytes());
+    }
+
+    /**
+     * Skips the next {@link String} part in the splitter.
+     *
+     * @throws BufferUnderflowException if there is no String as expected
+     */
+    public void skipString() {
+      skipBytes();
+    }
+
+    /**
+     * Returns the next byte[] part in the {@link Splitter}.
+     *
+     * @throws BufferUnderflowException if there is no byte[] as expected
+     * @return the next byte[] part in the {@link Splitter}
+     */
+    private byte[] getBytes() {
+      int len = byteBuffer.getInt();
+      if (byteBuffer.remaining() < len) {
+        throw new BufferUnderflowException();
+      }
+      byte[] bytes = new byte[len];
+      byteBuffer.get(bytes, 0, len);
+      return bytes;
+    }
+
+    /**
+     * Skips the next byte[] part in the {@link Splitter}.
+     *
+     * @throws BufferUnderflowException if there is no byte[] as expected
+     */
+    private void skipBytes() {
+      int len = byteBuffer.getInt();
+      int position = byteBuffer.position();
+      byteBuffer.position(position + len);
+    }
+  }
+
+  /**
+   * Builds an {@link ACLDatasetKey}.
+   */
+  public static final class Builder {
+    private byte[] key;
+
+    public Builder() {
+      key = new byte[0];
+    }
+
+    public Builder add(String part) {
+      add(Bytes.toBytes(part));
+      return this;
+    }
+
+    public ACLDatasetKey build() {
+      return new ACLDatasetKey(key);
+    }
+
+    // Encodes parts of the key with segments of <length> <value>
+    private Builder add(byte[] part) {
+      key = Bytes.add(key, Bytes.toBytes(part.length), part);
+      return this;
+    }
+  }
+}

--- a/cdap-authorization-dataset-extn/src/main/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizer.java
+++ b/cdap-authorization-dataset-extn/src/main/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizer.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetContext;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.InstanceConflictException;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.cdap.proto.security.Role;
+import co.cask.cdap.security.spi.authorization.AbstractAuthorizer;
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
+import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import co.cask.tephra.TransactionFailureException;
+import com.google.common.base.Splitter;
+import com.google.common.base.Supplier;
+import com.google.common.base.Throwables;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * {@link Authorizer} that uses a dataset to manage ACLs.
+ */
+public class DatasetBasedAuthorizer extends AbstractAuthorizer {
+  private static final Logger LOG = LoggerFactory.getLogger(DatasetBasedAuthorizer.class);
+  private final Set<Principal> superUsers = new HashSet<>();
+  private AuthorizationContext context;
+  private Supplier<ACLDataset> dsSupplier;
+
+  @Override
+  public void initialize(final AuthorizationContext context) throws Exception {
+    this.context = context;
+    this.dsSupplier = new Supplier<ACLDataset>() {
+      @Override
+      public ACLDataset get() {
+        try {
+          context.createDataset(ACLDataset.TABLE_NAME, "table", DatasetProperties.EMPTY);
+        } catch (InstanceConflictException e) {
+          LOG.info("Dataset {} already exists. Not creating again.", ACLDataset.TABLE_NAME);
+        } catch (DatasetManagementException e) {
+          throw Throwables.propagate(e);
+        }
+        Table table = context.getDataset(ACLDataset.TABLE_NAME);
+        return new ACLDataset(table);
+      }
+    };
+    Properties properties = context.getExtensionProperties();
+    if (!properties.containsKey("superusers")) {
+      LOG.warn("No superusers configured. The system may become unusable when authorization is enabled but " +
+                 "superusers are not configured. Please set the property " +
+                 "security.authorization.extension.config.superusers to a comma-separated list of superusers in " +
+                 "cdap-site.xml and restart CDAP.");
+      return;
+    }
+    for (String superuser : Splitter.on(",").trimResults().omitEmptyStrings()
+      .split(properties.getProperty("superusers"))) {
+      this.superUsers.add(new Principal(superuser, Principal.PrincipalType.USER));
+    }
+  }
+
+  @Override
+  public void enforce(final EntityId entity, final Principal principal,
+                      final Action action) throws UnauthorizedException, TransactionFailureException {
+    // no enforcement for superusers
+    if (superUsers.contains(principal)) {
+      return;
+    }
+    final AtomicReference<Boolean> result = new AtomicReference<>(false);
+    context.execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
+        for (EntityId current : entity.getHierarchy()) {
+          Set<Action> allowedActions = dataset.search(current, principal);
+          if (allowedActions.contains(Action.ALL) || allowedActions.contains(action)) {
+            result.set(true);
+            return;
+          }
+        }
+      }
+    });
+    if (!result.get()) {
+      throw new UnauthorizedException(principal, action, entity);
+    }
+  }
+
+  @Override
+  public void grant(final EntityId entity, final Principal principal,
+                    final Set<Action> actions) throws TransactionFailureException {
+    context.execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
+        for (Action action : actions) {
+          dataset.add(entity, principal, action);
+        }
+      }
+    });
+  }
+
+  @Override
+  public void revoke(final EntityId entity, final Principal principal,
+                     final Set<Action> actions) throws TransactionFailureException {
+    context.execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
+        for (Action action : actions) {
+          dataset.remove(entity, principal, action);
+        }
+      }
+    });
+  }
+
+  @Override
+  public void revoke(final EntityId entity) throws TransactionFailureException {
+    context.execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
+        dataset.remove(entity);
+      }
+    });
+  }
+
+  @Override
+  public Set<Privilege> listPrivileges(final Principal principal) throws TransactionFailureException {
+    final AtomicReference<Set<Privilege>> result = new AtomicReference<>();
+    context.execute(new TxRunnable() {
+      @Override
+      public void run(DatasetContext context) throws Exception {
+        ACLDataset dataset = dsSupplier.get();
+        result.set(dataset.listPrivileges(principal));
+      }
+    });
+    return result.get();
+  }
+
+  @Override
+  public void createRole(Role role) throws RoleAlreadyExistsException {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public void dropRole(Role role) throws RoleNotFoundException {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public void addRoleToPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public void removeRoleFromPrincipal(Role role, Principal principal) throws RoleNotFoundException {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public Set<Role> listRoles(Principal principal) {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+
+  @Override
+  public Set<Role> listAllRoles() {
+    throw new UnsupportedOperationException("Role based operation is not supported.");
+  }
+}

--- a/cdap-authorization-dataset-extn/src/test/java/co/cask/cdap/security/authorization/ACLDatasetTest.java
+++ b/cdap-authorization-dataset-extn/src/test/java/co/cask/cdap/security/authorization/ACLDatasetTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.table.Table;
+import co.cask.cdap.data2.dataset2.DatasetFrameworkTestUtil;
+import co.cask.cdap.proto.id.DatasetId;
+import co.cask.cdap.proto.id.Ids;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.proto.security.Privilege;
+import co.cask.tephra.TransactionExecutor;
+import co.cask.tephra.TransactionFailureException;
+import com.google.common.collect.ImmutableSet;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * Tests for {@link ACLDataset}.
+ */
+public class ACLDatasetTest {
+
+  @ClassRule
+  public static DatasetFrameworkTestUtil dsFrameworkUtil = new DatasetFrameworkTestUtil();
+
+  private static final DatasetId tabInstance = new DatasetId("myspace", "tab");
+  private static ACLDataset table;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    dsFrameworkUtil.createInstance("table", tabInstance.toId(), DatasetProperties.EMPTY);
+    table = new ACLDataset((Table) dsFrameworkUtil.getInstance(tabInstance.toId()));
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    dsFrameworkUtil.deleteInstance(tabInstance.toId());
+  }
+
+  @Test
+  public void testSearchAddRemove() throws InterruptedException, TransactionFailureException {
+    final NamespaceId namespace = Ids.namespace("foo");
+    final Principal user = new Principal("alice", Principal.PrincipalType.USER);
+
+    TransactionExecutor txnl = dsFrameworkUtil.newTransactionExecutor(table);
+
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        Assert.assertEquals(ImmutableSet.of(), table.search(namespace, user));
+      }
+    });
+    // single add and single remove
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        table.add(namespace, user, Action.READ);
+        Assert.assertEquals(ImmutableSet.of(Action.READ), table.search(namespace, user));
+        Assert.assertEquals(ImmutableSet.of(new Privilege(namespace, Action.READ)), table.listPrivileges(user));
+        table.remove(namespace, user, Action.READ);
+        Assert.assertEquals(ImmutableSet.of(), table.search(namespace, user));
+      }
+    });
+
+    // two adds and batch remove
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        table.add(namespace, user, Action.READ);
+        table.add(namespace, user, Action.WRITE);
+        Assert.assertEquals(ImmutableSet.of(Action.READ, Action.WRITE), table.search(namespace, user));
+        table.remove(namespace, user);
+        Assert.assertEquals(ImmutableSet.of(), table.search(namespace, user));
+      }
+    });
+
+    // two adds and batch remove
+    txnl.execute(new TransactionExecutor.Subroutine() {
+      @Override
+      public void apply() throws Exception {
+        table.add(namespace, user, Action.READ);
+        table.add(namespace, user, Action.WRITE);
+        Assert.assertEquals(ImmutableSet.of(Action.READ, Action.WRITE), table.search(namespace, user));
+        table.remove(namespace);
+        Assert.assertEquals(ImmutableSet.of(), table.search(namespace, user));
+      }
+    });
+  }
+
+}

--- a/cdap-authorization-dataset-extn/src/test/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizerTest.java
+++ b/cdap-authorization-dataset-extn/src/test/java/co/cask/cdap/security/authorization/DatasetBasedAuthorizerTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2015-2016 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.cask.cdap.security.authorization;
+
+import co.cask.cdap.api.Admin;
+import co.cask.cdap.api.Transactional;
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.dataset.module.DatasetDefinitionRegistry;
+import co.cask.cdap.api.dataset.module.DatasetModule;
+import co.cask.cdap.api.metrics.MetricsCollectionService;
+import co.cask.cdap.common.guice.ConfigModule;
+import co.cask.cdap.common.metrics.NoOpMetricsCollectionService;
+import co.cask.cdap.data.dataset.SystemDatasetInstantiator;
+import co.cask.cdap.data2.dataset2.DatasetDefinitionRegistryFactory;
+import co.cask.cdap.data2.dataset2.DatasetFramework;
+import co.cask.cdap.data2.dataset2.DefaultDatasetDefinitionRegistry;
+import co.cask.cdap.data2.dataset2.DynamicDatasetCache;
+import co.cask.cdap.data2.dataset2.InMemoryDatasetFramework;
+import co.cask.cdap.data2.dataset2.SingleThreadDatasetCache;
+import co.cask.cdap.data2.dataset2.module.lib.inmemory.InMemoryTableModule;
+import co.cask.cdap.internal.app.runtime.DefaultAdmin;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
+import co.cask.cdap.security.spi.authorization.Authorizer;
+import co.cask.cdap.security.spi.authorization.AuthorizerTest;
+import co.cask.tephra.TransactionContext;
+import co.cask.tephra.TransactionFailureException;
+import co.cask.tephra.TransactionManager;
+import co.cask.tephra.TransactionSystemClient;
+import co.cask.tephra.runtime.TransactionInMemoryModule;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import com.google.inject.assistedinject.FactoryModuleBuilder;
+import com.google.inject.multibindings.MapBinder;
+import com.google.inject.name.Names;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Properties;
+
+/**
+ * Tests for {@link DatasetBasedAuthorizer}.
+ */
+public class DatasetBasedAuthorizerTest extends AuthorizerTest {
+
+  private static final DatasetBasedAuthorizer datasetAuthorizer = new DatasetBasedAuthorizer();
+  private static TransactionManager txManager;
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    Injector injector = Guice.createInjector(
+      new TransactionInMemoryModule(),
+      new ConfigModule(),
+      new AbstractModule() {
+        @Override
+        protected void configure() {
+          install(new FactoryModuleBuilder()
+                    .implement(DatasetDefinitionRegistry.class, DefaultDatasetDefinitionRegistry.class)
+                    .build(DatasetDefinitionRegistryFactory.class));
+
+          MapBinder<String, DatasetModule> mapBinder = MapBinder.newMapBinder(
+            binder(), String.class, DatasetModule.class, Names.named("defaultDatasetModules"));
+          mapBinder.addBinding("orderedTable-memory").toInstance(new InMemoryTableModule());
+
+          bind(DatasetFramework.class).to(InMemoryDatasetFramework.class).in(Scopes.SINGLETON);
+          bind(MetricsCollectionService.class).to(NoOpMetricsCollectionService.class);
+        }
+      }
+    );
+
+    txManager = injector.getInstance(TransactionManager.class);
+    txManager.startAndWait();
+
+    DatasetFramework dsFramework = injector.getInstance(DatasetFramework.class);
+    SystemDatasetInstantiator instantiator = new SystemDatasetInstantiator(dsFramework, null, null);
+    TransactionSystemClient txClient = injector.getInstance(TransactionSystemClient.class);
+    final DynamicDatasetCache dsCache = new SingleThreadDatasetCache(instantiator, txClient, NamespaceId.DEFAULT,
+                                                                     ImmutableMap.<String, String>of(), null, null);
+    Admin admin = new DefaultAdmin(dsFramework, NamespaceId.DEFAULT);
+    Transactional txnl = new Transactional() {
+      @Override
+      public void execute(TxRunnable runnable) throws TransactionFailureException {
+        TransactionContext transactionContext = dsCache.get();
+        transactionContext.start();
+        try {
+          runnable.run(dsCache);
+        } catch (TransactionFailureException e) {
+          transactionContext.abort(e);
+        } catch (Throwable t) {
+          transactionContext.abort(new TransactionFailureException("Exception raised from TxRunnable.run()", t));
+        }
+        transactionContext.finish();
+      }
+    };
+    AuthorizationContext authContext = new DefaultAuthorizationContext(new Properties(), dsCache, admin, txnl);
+    datasetAuthorizer.initialize(authContext);
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    datasetAuthorizer.destroy();
+    txManager.stopAndWait();
+  }
+
+  @Override
+  protected Authorizer get() {
+    return datasetAuthorizer;
+  }
+
+  @Override
+  @Test(expected = UnsupportedOperationException.class)
+  public void testRBAC() throws Exception {
+    // DatasetBasedAuthorizer currently does not support role based access control
+    super.testRBAC();
+  }
+}


### PR DESCRIPTION
Moves the `cdap-authorization-dataset-plugin` to the `cdap-security-extn` repo. 

This PR contains no changes. Just moves (copies) the directory here with all the commit history.

Will send follow-up PRs for:
- Including this extension in the `cdap-security-extn` build
- Removing the `cdap-authorization-dataset-plugin` from the CDAP repo
