### PR TITLE
- Use Apache Sentry 1.7.0 in release/0.1.0

### DIFF
--- a/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/AuthBinding.java
+++ b/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/AuthBinding.java
@@ -18,10 +18,10 @@ package co.cask.cdap.security.authorization.sentry.binding;
 
 import co.cask.cdap.proto.element.EntityType;
 import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
-import co.cask.cdap.proto.id.NamespacedArtifactId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
@@ -507,7 +507,7 @@ class AuthBinding {
         authorizables.add(new Namespace(((NamespaceId) entityId).getNamespace()));
         break;
       case ARTIFACT:
-        NamespacedArtifactId artifactId = (NamespacedArtifactId) entityId;
+        ArtifactId artifactId = (ArtifactId) entityId;
         getAuthorizable(artifactId.getParent(), authorizables);
         authorizables.add(new Artifact((artifactId).getArtifact()));
         break;
@@ -537,13 +537,8 @@ class AuthBinding {
   }
 
   private String getRequestingUser() throws IllegalArgumentException {
-    // Preconditions.checkArgument(!SecurityRequestContext.getUserId().isPresent(), "No authenticated user found.");
-    // TODO Issues-15: To support testing on insecure clusters where we don't have security in cdap we will returning a
-    // dummy username. Once the development is almost finalized we should remove the below dummy username and
-    // uncomment the line above.
-    if (SecurityRequestContext.getUserId() == null) {
-      return "cdap";
-    }
+     Preconditions.checkArgument(SecurityRequestContext.getUserId() != null, "No authenticated user found. Please " +
+       "verify that authentication is enabled in CDAP.");
     return SecurityRequestContext.getUserId();
   }
 }

--- a/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
+++ b/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
@@ -18,10 +18,10 @@ package co.cask.cdap.security.authorization.sentry.binding;
 
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
-import co.cask.cdap.proto.id.NamespacedArtifactId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.security.authorization.sentry.model.Application;
@@ -63,7 +63,7 @@ public class AuthBindingEntityToAuthMapperTest {
     Assert.assertEquals(getAuthorizablesList(AuthorizableType.NAMESPACE), authorizables);
 
     // artifact
-    entityId = new NamespacedArtifactId(NAMESPACE, ARTIFACT, ARTIFACT_VERSION);
+    entityId = new ArtifactId(NAMESPACE, ARTIFACT, ARTIFACT_VERSION);
     authorizables = AuthBinding.convertEntityToAuthorizables(INSTANCE, entityId);
     Assert.assertEquals(getAuthorizablesList(AuthorizableType.ARTIFACT), authorizables);
 

--- a/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
+++ b/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
@@ -24,10 +24,10 @@ import co.cask.cdap.api.dataset.DatasetProperties;
 import co.cask.cdap.api.dataset.InstanceNotFoundException;
 import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.id.ApplicationId;
+import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
 import co.cask.cdap.proto.id.NamespaceId;
-import co.cask.cdap.proto.id.NamespacedArtifactId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
@@ -136,7 +136,7 @@ public class SentryAuthorizerTest {
     testAuthorized(new NamespaceId("ns1"));
     testAuthorized(new StreamId("ns1", "stream1"));
     testAuthorized(new DatasetId("ns1", "ds1"));
-    testAuthorized(new NamespacedArtifactId("ns1", "art", "1"));
+    testAuthorized(new ArtifactId("ns1", "art", "1"));
     testAuthorized(new ApplicationId("ns1", "app1"));
     testAuthorized(new ProgramId("ns1", "app1", ProgramType.MAPREDUCE, "prog1"));
 

--- a/cdap-sentry/pom.xml
+++ b/cdap-sentry/pom.xml
@@ -71,7 +71,7 @@
 
   <properties>
     <hadoop.version>2.3.0</hadoop.version>
-    <sentry.version>1.7.0-incubating-SNAPSHOT</sentry.version>
+    <sentry.version>1.7.0</sentry.version>
   </properties>
 
   <repositories>
@@ -182,6 +182,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
- Set source/target versions for maven-compiler-plugins
- Remove hard-coded username when authentication is disabled #15 

Build: http://builds.cask.co/browse/CDAP-CSI13-1
