### PR TITLE
Feature/create dot role

### DIFF
--- a/cdap-sentry/README.rst
+++ b/cdap-sentry/README.rst
@@ -79,10 +79,14 @@ authorization extension:
      - Absolute path of the ``cdap-sentry-binding-*.jar`` on the local file system of the CDAP Master.
    * - ``security.authorization.authorizer.extension.config.sentry.site.url``
      - Absolute path of the client-side ``sentry-site.xml`` on the local file system of the CDAP Master.
-   * - ``security.authorization.authorizer.extension.config.cdap.superusers``
+   * - ``security.authorization.authorizer.extension.config.sentry.admin.group``
+     - A unix group configured as an admin group in the Sentry Service (identified by ``sentry.service.admin.group``
+       in the ``sentry-site.xml`` used by the Sentry Service). This group is used while granting ``ALL`` privileges
+       to a user when he/she successfully creates an entity.
+   * - ``security.authorization.authorizer.extension.config.superusers``
      - Comma-separated list of super users. Super users are authorized to perform all operations on all entities.
        They can also manage roles.
-   * - ``security.authorization.authorizer.extension.config.cdap.instance.name``
+   * - ``security.authorization.authorizer.extension.config.instance.name``
      - String to use to identify the CDAP Instance. Defaults to 'cdap'.
 
 - Restart CDAP Master.

--- a/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizer.java
+++ b/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizer.java
@@ -22,6 +22,7 @@ import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.proto.security.Role;
 import co.cask.cdap.security.authorization.sentry.binding.conf.AuthConf;
+import co.cask.cdap.security.spi.authentication.SecurityRequestContext;
 import co.cask.cdap.security.spi.authorization.AbstractAuthorizer;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
 import co.cask.cdap.security.spi.authorization.Authorizer;
@@ -29,10 +30,13 @@ import co.cask.cdap.security.spi.authorization.RoleAlreadyExistsException;
 import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
 
@@ -43,7 +47,9 @@ import java.util.Set;
 public class SentryAuthorizer extends AbstractAuthorizer {
 
   private static final Logger LOG = LoggerFactory.getLogger(SentryAuthorizer.class);
+  private static final String ENTITY_ROLE_PREFIX = ".";
   private AuthBinding binding;
+  private String sentryAdminGroup;
 
   public SentryAuthorizer() {
   }
@@ -56,67 +62,86 @@ public class SentryAuthorizer extends AbstractAuthorizer {
                                 "Path to sentry-site.xml path is not specified in cdap-site.xml. Please provide the " +
                                   "path to sentry-site.xml in cdap-site.xml with property name %s",
                                 AuthConf.SENTRY_SITE_URL);
-    String superUsers = properties.getProperty(AuthConf.SERVICE_SUPERUSERS);
+    String superUsers = properties.getProperty(AuthConf.SUPERUSERS);
     Preconditions.checkArgument(!Strings.isNullOrEmpty(superUsers),
-                                "No superUsers found in cdap-site.xml. Please provide a comma separated list of " +
+                                "No superusers defined in cdap-site.xml. Please provide a comma separated list of " +
                                   "users who will be superusers with property name %s. Example: user1,user2",
-                                AuthConf.SERVICE_SUPERUSERS);
-    String serviceInstanceName = properties.containsKey(AuthConf.SERVICE_INSTANCE_NAME) ?
-      properties.getProperty(AuthConf.SERVICE_INSTANCE_NAME) :
-      AuthConf.AuthzConfVars.getDefault(AuthConf.SERVICE_INSTANCE_NAME);
+                                AuthConf.SUPERUSERS);
+
+    this.sentryAdminGroup = properties.getProperty(AuthConf.SENTRY_ADMIN_GROUP);
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(sentryAdminGroup),
+                                "No Sentry admin groups defined in cdap-site.xml. Please set %s in cdap-site.xml " +
+                                  "to a single admin group defined in the sentry service. This group will be used to " +
+                                  "grant access to users after they have created entities in CDAP",
+                                AuthConf.SENTRY_ADMIN_GROUP);
+    Preconditions.checkArgument(!sentryAdminGroup.contains(","),
+                                "Please provide exactly one Sentry admin group at %s in cdap-site.xml. Found '%s'.",
+                                AuthConf.SENTRY_ADMIN_GROUP, sentryAdminGroup);
+    String instanceName = properties.containsKey(AuthConf.INSTANCE_NAME) ?
+      properties.getProperty(AuthConf.INSTANCE_NAME) :
+      AuthConf.AuthzConfVars.getDefault(AuthConf.INSTANCE_NAME);
 
     LOG.info("Configuring SentryAuthorizer with sentry-site.xml at {} and cdap instance name {}",
-               sentrySiteUrl, serviceInstanceName);
-    this.binding = new AuthBinding(sentrySiteUrl, superUsers, serviceInstanceName);
+               sentrySiteUrl, instanceName);
+    Set<Principal> superUsersPrincipals = getSuperUsers(superUsers);
+    this.binding = new AuthBinding(sentrySiteUrl, superUsersPrincipals, instanceName);
   }
 
   @Override
   public void grant(EntityId entityId, Principal principal, Set<Action> actions) throws RoleNotFoundException {
-    Preconditions.checkArgument(principal.getType() == Principal.PrincipalType.ROLE,
-                                "The given principal '%s' is of type '%s'. In Sentry grants can only be done on " +
-                                  "roles. Please add the '%s':'%s' to a role and perform grant on the role.",
-                                principal.getName(), principal.getType(),
-                                principal.getType(), principal.getName());
-    binding.grant(entityId, new Role(principal.getName()), actions);
+    switch (principal.getType()) {
+      case ROLE:
+        binding.grant(entityId, new Role(principal.getName()), actions, getRequestingUser());
+        break;
+      case USER:
+        performUserBasedGrant(entityId, principal, actions);
+        break;
+      default:
+        throw new IllegalArgumentException(
+          String.format("The given principal '%s' is of type '%s'. In Sentry grants can only be done on " +
+                          "roles. Please add the '%s':'%s' to a role and perform grant on the role.",
+                        principal.getName(), principal.getType(), principal.getType(), principal.getName()));
+    }
   }
-
 
   @Override
   public void revoke(EntityId entityId, Principal principal, Set<Action> actions) throws RoleNotFoundException {
     Preconditions.checkArgument(principal.getType() == Principal.PrincipalType.ROLE, "The given principal '%s' is of " +
                                   "type '%s'. In Sentry revoke can only be done on roles.",
                                 principal.getName(), principal.getType());
-    binding.revoke(entityId, new Role(principal.getName()), actions);
+    binding.revoke(entityId, new Role(principal.getName()), actions, getRequestingUser());
   }
 
   @Override
-  public void revoke(EntityId entityId) {
-    binding.revoke(entityId);
+  public void revoke(EntityId entityId) throws RoleNotFoundException {
+    binding.revoke(entityId, getRequestingUser());
+    // remove the role created for this entity
+    binding.dropRole(new Role(ENTITY_ROLE_PREFIX + entityId.toString()), sentryAdminGroup);
   }
 
   @Override
   public Set<Privilege> listPrivileges(Principal principal) {
-    return binding.listPrivileges(principal);
+    return binding.listPrivileges(principal, getRequestingUser());
   }
 
   @Override
   public void createRole(Role role) throws RoleAlreadyExistsException {
-    binding.createRole(role);
+    binding.createRole(role, getRequestingUser());
   }
 
   @Override
   public void dropRole(Role role) throws RoleNotFoundException {
-    binding.dropRole(role);
+    binding.dropRole(role, getRequestingUser());
   }
 
   @Override
   public void addRoleToPrincipal(Role role, Principal principal) throws RoleNotFoundException {
-    binding.addRoleToGroup(role, principal);
+    binding.addRoleToGroup(role, principal, getRequestingUser());
   }
 
   @Override
   public void removeRoleFromPrincipal(Role role, Principal principal) throws RoleNotFoundException {
-    binding.removeRoleFromGroup(role, principal);
+    binding.removeRoleFromGroup(role, principal, getRequestingUser());
   }
 
   @Override
@@ -125,12 +150,12 @@ public class SentryAuthorizer extends AbstractAuthorizer {
                                 "type '%s'. In Sentry revoke roles can only be listed for '%s' and '%s'",
                                 principal.getName(), principal.getType(), Principal.PrincipalType.USER,
                                 Principal.PrincipalType.GROUP);
-    return binding.listRolesForGroup(principal);
+    return binding.listRolesForGroup(principal, getRequestingUser());
   }
 
   @Override
   public Set<Role> listAllRoles() {
-    return binding.listAllRoles();
+    return binding.listAllRoles(getRequestingUser());
   }
 
   @Override
@@ -138,9 +163,53 @@ public class SentryAuthorizer extends AbstractAuthorizer {
     Preconditions.checkArgument(principal.getType() == Principal.PrincipalType.USER, "The given principal '%s' is of " +
                                 "type '%s'. In Sentry authorization checks can only be performed on principal type " +
                                 "'%s'.", principal.getName(), principal.getType(), Principal.PrincipalType.USER);
-    boolean authorize = binding.authorize(entityId, principal, action);
-    if (!authorize) {
+    if (!binding.authorize(entityId, principal, action)) {
       throw new UnauthorizedException(principal, action, entityId);
     }
+  }
+
+  private synchronized void performUserBasedGrant(EntityId entityId, Principal principal, Set<Action> actions) {
+    // make sure that the request is part of a larger request for creating an entity
+    if (!Collections.singleton(Action.ALL).equals(actions)) {
+      throw new IllegalArgumentException("Grants for users are only supported in Sentry as part of a create " +
+                                           "operation.");
+    }
+    Role dotRole = new Role(ENTITY_ROLE_PREFIX + entityId.toString());
+    try {
+      binding.createRole(dotRole, sentryAdminGroup);
+    } catch (RoleAlreadyExistsException e) {
+      LOG.debug("Dot role {} already exists.");
+    }
+    try {
+      binding.addRoleToGroup(dotRole, new Principal(principal.getName(), Principal.PrincipalType.GROUP),
+                             sentryAdminGroup);
+      // #36 Ideally the requesting user here could be the getRequestingUser(), but AuthBinding.grant checks for the
+      // existence of the role, which involves listing all roles, which is only allowed for sentry admin groups.
+      binding.grant(entityId, dotRole, actions, sentryAdminGroup);
+    } catch (RoleNotFoundException e) {
+      // Not possible, since we just made sure it exists, and this method is synchronized
+      LOG.warn("Role {} not found. This is unexpected since its existence was just ensured.", dotRole);
+    }
+  }
+
+  /**
+   * Gets a {@link Set} of {@link Principal} of superusers which is provided through
+   * {@link AuthConf#SUPERUSERS}
+   *
+   * @return {@link Set} of {@link Principal} of superusers
+   */
+  private Set<Principal> getSuperUsers(String superUsers) {
+    Set<Principal> result = new HashSet<>();
+    for (String curUser : Splitter.on(",").trimResults().split(superUsers)) {
+      result.add(new Principal(curUser, Principal.PrincipalType.USER));
+    }
+    return result;
+  }
+
+  private String getRequestingUser() throws IllegalArgumentException {
+    String requestingUser = SecurityRequestContext.getUserId();
+    Preconditions.checkArgument(requestingUser != null, "No authenticated user found. Please " +
+      "verify that authentication is enabled in CDAP.");
+    return requestingUser;
   }
 }

--- a/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/conf/AuthConf.java
+++ b/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/conf/AuthConf.java
@@ -31,12 +31,12 @@ public class AuthConf extends Configuration {
 
   // sentry-site.xml path
   public static final String SENTRY_SITE_URL = "sentry.site.url";
-  // cdap instance name to be used in sentry for example: cdap
-  public static final String SERVICE_INSTANCE_NAME = "instance.name";
-  // cdap username to be used in sentry for example: cdap
-  public static final String SERVICE_USER_NAME = "user.name";
+  // an admin group in sentry service that can create roles
+  public static final String SENTRY_ADMIN_GROUP = "sentry.admin.group";
+  // cdap instance name to be used in sentry
+  public static final String INSTANCE_NAME = "instance.name";
   // a comma separated list of users who will be superusers
-  public static final String SERVICE_SUPERUSERS = "superusers";
+  public static final String SUPERUSERS = "superusers";
 
   /**
    * Config setting definitions
@@ -47,9 +47,9 @@ public class AuthConf extends Configuration {
     AUTHZ_POLICY_ENGINE("sentry.cdap.policy.engine", SimplePolicyEngine.class.getName()),
     AUTHZ_PROVIDER_RESOURCE("sentry.cdap.provider.resource", ""),
     // if no instanceName or username is provided 'cdap' will be used
-    AUTHZ_SERVICE_INSTANCE_NAME(SERVICE_INSTANCE_NAME, "cdap"),
-    AUTHZ_SERVICE_USER_NAME(SERVICE_USER_NAME, "cdap"),
-    AUTHZ_SERVICE_SUPERUSERS(SERVICE_SUPERUSERS, "");
+    AUTHZ_SERVICE_INSTANCE_NAME(INSTANCE_NAME, "cdap"),
+    AUTHZ_SENTRY_ADMIN_GROUP(SENTRY_ADMIN_GROUP, "cdap"),
+    AUTHZ_SUPERUSERS(SUPERUSERS, "");
 
     private final String varName;
     private final String defaultVal;

--- a/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
+++ b/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
@@ -26,6 +26,7 @@ import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
 import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.authorization.sentry.model.Application;
 import co.cask.cdap.security.authorization.sentry.model.Artifact;
@@ -43,8 +44,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.URL;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Test for {@link AuthBinding#toSentryAuthorizables(EntityId)}. For others please see
@@ -68,7 +71,8 @@ public class AuthBindingEntityToAuthMapperTest {
     URL resource = AuthBindingEntityToAuthMapperTest.class.getClassLoader().getResource("sentry-site.xml");
     Assert.assertNotNull(resource);
     String sentrySitePath = resource.getPath();
-    binding = new AuthBinding(sentrySitePath, "superUser", "cdap");
+    Set<Principal> superUsers = Collections.singleton(new Principal("superUser", Principal.PrincipalType.USER));
+    binding = new AuthBinding(sentrySitePath, superUsers, "cdap");
   }
 
   @Test

--- a/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
+++ b/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
@@ -59,7 +59,9 @@ public class SentryAuthorizerTest {
     String sentrySitePath = resource.getPath();
     final Properties properties = new Properties();
     properties.put(AuthConf.SENTRY_SITE_URL, sentrySitePath);
-    properties.put(AuthConf.SERVICE_SUPERUSERS, Joiner.on(",").join(SUPERUSER_HULK, SUPERUSER_SPIDERMAN));
+    properties.put(AuthConf.INSTANCE_NAME, "cdap");
+    properties.put(AuthConf.SUPERUSERS, Joiner.on(",").join(SUPERUSER_HULK, SUPERUSER_SPIDERMAN));
+    properties.put(AuthConf.SENTRY_ADMIN_GROUP, "cdap");
     this.authorizer = new SentryAuthorizer();
     authorizer.initialize(new AuthorizationContext() {
       @Override
@@ -181,6 +183,33 @@ public class SentryAuthorizerTest {
     assertAuthorized(new StreamId("ns2", "stream1"), getUser(SUPERUSER_SPIDERMAN), Action.ADMIN);
   }
 
+  @Test
+  public void testHierarchy() {
+    // admin1 has ADMIN on ns1
+    assertAuthorized(new NamespaceId("ns1"), getUser("admin1"), Action.ADMIN);
+    // hence, admin1 should have ADMIN on any child of ns1, even a child that admin1 has not been given explicit ADMIN
+    // access's on in the authz-provider.ini
+    assertAuthorized(new StreamId("ns1", "notconfigured"), getUser("admin1"), Action.ADMIN);
+    assertAuthorized(new DatasetId("ns1", "notconfigured"), getUser("admin1"), Action.ADMIN);
+    assertAuthorized(new ArtifactId("ns1", "notconfigured", "1.0"), getUser("admin1"), Action.ADMIN);
+    assertAuthorized(new ApplicationId("ns1", "notconfigured"), getUser("admin1"), Action.ADMIN);
+    assertAuthorized(new ProgramId("ns1", "foo", ProgramType.SPARK, "bar"), getUser("admin1"), Action.ADMIN);
+
+    // however, admin1 should not get ADMIN on a children of ns2 via hierarchy
+    assertUnauthorized(new StreamId("ns2", "notconfigured"), getUser("admin1"), Action.ADMIN);
+    assertUnauthorized(new DatasetId("ns2", "notconfigured"), getUser("admin1"), Action.ADMIN);
+    assertUnauthorized(new ArtifactId("ns2", "notconfigured", "1.0"), getUser("admin1"), Action.ADMIN);
+    assertUnauthorized(new ApplicationId("ns2", "notconfigured"), getUser("admin1"), Action.ADMIN);
+    assertUnauthorized(new ProgramId("ns2", "foo", ProgramType.SPARK, "bar"), getUser("admin1"), Action.ADMIN);
+
+    // readers1 have READ on app1 in ns1
+    assertAuthorized(new ApplicationId("ns1", "app1"), getUser("readers1"), Action.READ);
+    // as a result, readers1 should get READ on any program in app1, even ones that have not been explicitly
+    // configured in authz-provider.ini
+    assertAuthorized(new ProgramId("ns1", "app1", ProgramType.MAPREDUCE, "notconfigured"),
+                     getUser("readers1"), Action.READ);
+  }
+
   private void testAuthorized(EntityId entityId) {
     // admin1 is admin of entity
     assertAuthorized(entityId, getUser("admin1"), Action.ADMIN);
@@ -206,8 +235,8 @@ public class SentryAuthorizerTest {
     try {
       authorizer.enforce(entityId, principal, action);
       Assert.fail("The authorization check should have failed.");
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof UnauthorizedException);
+    } catch (UnauthorizedException expected) {
+      // expected
     }
   }
 

--- a/cdap-sentry/cdap-sentry-policy/src/test/java/co/cask/cdap/security/authorization/sentry/policy/TestWildcardPrivilege.java
+++ b/cdap-sentry/cdap-sentry-policy/src/test/java/co/cask/cdap/security/authorization/sentry/policy/TestWildcardPrivilege.java
@@ -22,7 +22,11 @@ import org.apache.sentry.policy.common.PolicyConstants;
 import org.apache.sentry.policy.common.Privilege;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -242,6 +246,128 @@ public class TestWildcardPrivilege {
   }
 
   @Test
+  public void testHierarchyForAll() {
+    for (Privilege nsPrivilege :
+      new Privilege[] {NAMESPACE1_ALL, NAMESPACE1_ADMIN, NAMESPACE1_READ, NAMESPACE1_WRITE, NAMESPACE1_EXECUTE}) {
+      assertTrue(INSTANCE1_ALL.implies(nsPrivilege));
+    }
+
+    for (Privilege artifactPrivilege :
+      new Privilege[] {ARTIFACT1_ALL, ARTIFACT1_ADMIN, ARTIFACT1_READ, ARTIFACT1_WRITE, ARTIFACT1_EXECUTE}) {
+      assertTrue(INSTANCE1_ALL.implies(artifactPrivilege));
+      assertTrue(NAMESPACE1_ALL.implies(artifactPrivilege));
+    }
+
+    for (Privilege appPrivilege :
+      new Privilege[] {APPLICATION1_ALL, APPLICATION1_ADMIN, APPLICATION1_READ, APPLICATION1_WRITE,
+        APPLICATION1_EXECUTE}) {
+      assertTrue(INSTANCE1_ALL.implies(appPrivilege));
+      assertTrue(NAMESPACE1_ALL.implies(appPrivilege));
+    }
+
+    for (Privilege programPrivilege :
+      new Privilege[] {PROGRAM1_ALL, PROGRAM1_ADMIN, PROGRAM1_READ, PROGRAM1_WRITE, PROGRAM1_EXECUTE}) {
+      assertTrue(INSTANCE1_ALL.implies(programPrivilege));
+      assertTrue(NAMESPACE1_ALL.implies(programPrivilege));
+      assertTrue(APPLICATION1_ALL.implies(programPrivilege));
+    }
+
+    for (Privilege dsPrivilege :
+      new Privilege[] {DATASET1_ALL, DATASET1_ADMIN, DATASET1_READ, DATASET1_WRITE, DATASET1_EXECUTE}) {
+      assertTrue(INSTANCE1_ALL.implies(dsPrivilege));
+      assertTrue(NAMESPACE1_ALL.implies(dsPrivilege));
+    }
+
+    for (Privilege streamPrivilege :
+      new Privilege[] {STREAM1_ALL, STREAM1_ADMIN, STREAM1_READ, STREAM1_WRITE, STREAM1_EXECUTE}) {
+      assertTrue(INSTANCE1_ALL.implies(streamPrivilege));
+      assertTrue(NAMESPACE1_ALL.implies(streamPrivilege));
+    }
+  }
+
+  @Test
+  public void testHierarchy() {
+    Privilege[] adminPrivileges =
+      new Privilege[]{INSTANCE1_ADMIN, NAMESPACE1_ADMIN, APPLICATION1_ADMIN, PROGRAM1_ADMIN, ARTIFACT1_ADMIN,
+        DATASET1_ADMIN, STREAM1_ADMIN};
+    Privilege[] readPrivileges =
+      new Privilege[]{INSTANCE1_READ, NAMESPACE1_READ, APPLICATION1_READ, PROGRAM1_READ, ARTIFACT1_READ,
+        DATASET1_READ, STREAM1_READ};
+    Privilege[] writePrivileges =
+      new Privilege[]{INSTANCE1_WRITE, NAMESPACE1_WRITE, APPLICATION1_WRITE, PROGRAM1_WRITE, ARTIFACT1_WRITE,
+        DATASET1_WRITE, STREAM1_WRITE};
+    Privilege[] executePrivileges =
+      new Privilege[]{INSTANCE1_EXECUTE, NAMESPACE1_EXECUTE, APPLICATION1_EXECUTE, PROGRAM1_EXECUTE, ARTIFACT1_EXECUTE,
+        DATASET1_EXECUTE, STREAM1_EXECUTE};
+    for (Privilege adminPrivilege : adminPrivileges) {
+      assertTrue(INSTANCE1_ADMIN.implies(adminPrivilege));
+      assertFalse(INSTANCE1_READ.implies(adminPrivilege));
+      assertFalse(INSTANCE1_WRITE.implies(adminPrivilege));
+      assertFalse(INSTANCE1_EXECUTE.implies(adminPrivilege));
+    }
+    for (Privilege readPrivilege : readPrivileges) {
+      assertFalse(INSTANCE1_ADMIN.implies(readPrivilege));
+      assertTrue(INSTANCE1_READ.implies(readPrivilege));
+      assertFalse(INSTANCE1_WRITE.implies(readPrivilege));
+      assertFalse(INSTANCE1_EXECUTE.implies(readPrivilege));
+    }
+    for (Privilege writePrivilege : writePrivileges) {
+      assertFalse(INSTANCE1_ADMIN.implies(writePrivilege));
+      assertFalse(INSTANCE1_READ.implies(writePrivilege));
+      assertTrue(INSTANCE1_WRITE.implies(writePrivilege));
+      assertFalse(INSTANCE1_EXECUTE.implies(writePrivilege));
+    }
+    for (Privilege executePrivilege : executePrivileges) {
+      assertFalse(INSTANCE1_ADMIN.implies(executePrivilege));
+      assertFalse(INSTANCE1_READ.implies(executePrivilege));
+      assertFalse(INSTANCE1_WRITE.implies(executePrivilege));
+      assertTrue(INSTANCE1_EXECUTE.implies(executePrivilege));
+    }
+    for (Privilege adminNsChildPrivilege : Arrays.copyOfRange(adminPrivileges, 1, adminPrivileges.length)) {
+      assertTrue(NAMESPACE1_ADMIN.implies(adminNsChildPrivilege));
+      assertFalse(NAMESPACE1_READ.implies(adminNsChildPrivilege));
+      assertFalse(NAMESPACE1_WRITE.implies(adminNsChildPrivilege));
+      assertFalse(NAMESPACE1_EXECUTE.implies(adminNsChildPrivilege));
+    }
+    for (Privilege readNsChildPrivilege : Arrays.copyOfRange(readPrivileges, 1, readPrivileges.length)) {
+      assertFalse(NAMESPACE1_ADMIN.implies(readNsChildPrivilege));
+      assertTrue(NAMESPACE1_READ.implies(readNsChildPrivilege));
+      assertFalse(NAMESPACE1_WRITE.implies(readNsChildPrivilege));
+      assertFalse(NAMESPACE1_EXECUTE.implies(readNsChildPrivilege));
+    }
+    for (Privilege writeNsChildPrivilege : Arrays.copyOfRange(writePrivileges, 1, writePrivileges.length)) {
+      assertFalse(NAMESPACE1_ADMIN.implies(writeNsChildPrivilege));
+      assertFalse(NAMESPACE1_READ.implies(writeNsChildPrivilege));
+      assertTrue(NAMESPACE1_WRITE.implies(writeNsChildPrivilege));
+      assertFalse(NAMESPACE1_EXECUTE.implies(writeNsChildPrivilege));
+    }
+    for (Privilege executeNsChildPrivilege : Arrays.copyOfRange(executePrivileges, 1, executePrivileges.length)) {
+      assertFalse(NAMESPACE1_ADMIN.implies(executeNsChildPrivilege));
+      assertFalse(NAMESPACE1_READ.implies(executeNsChildPrivilege));
+      assertFalse(NAMESPACE1_WRITE.implies(executeNsChildPrivilege));
+      assertTrue(NAMESPACE1_EXECUTE.implies(executeNsChildPrivilege));
+    }
+
+    // Test app -> program hierarchy
+    assertTrue(APPLICATION1_ADMIN.implies(PROGRAM1_ADMIN));
+    assertFalse(APPLICATION1_ADMIN.implies(PROGRAM1_READ));
+    assertFalse(APPLICATION1_ADMIN.implies(PROGRAM1_WRITE));
+    assertFalse(APPLICATION1_ADMIN.implies(PROGRAM1_EXECUTE));
+    assertFalse(APPLICATION1_READ.implies(PROGRAM1_ADMIN));
+    assertTrue(APPLICATION1_READ.implies(PROGRAM1_READ));
+    assertFalse(APPLICATION1_READ.implies(PROGRAM1_WRITE));
+    assertFalse(APPLICATION1_READ.implies(PROGRAM1_EXECUTE));
+    assertFalse(APPLICATION1_WRITE.implies(PROGRAM1_ADMIN));
+    assertFalse(APPLICATION1_WRITE.implies(PROGRAM1_READ));
+    assertTrue(APPLICATION1_WRITE.implies(PROGRAM1_WRITE));
+    assertFalse(APPLICATION1_WRITE.implies(PROGRAM1_EXECUTE));
+    assertFalse(APPLICATION1_EXECUTE.implies(PROGRAM1_ADMIN));
+    assertFalse(APPLICATION1_EXECUTE.implies(PROGRAM1_READ));
+    assertFalse(APPLICATION1_EXECUTE.implies(PROGRAM1_WRITE));
+    assertTrue(APPLICATION1_EXECUTE.implies(PROGRAM1_EXECUTE));
+  }
+
+  @Test
   public void testUnexpected() throws Exception {
     Privilege p = new Privilege() {
       @Override
@@ -252,7 +378,7 @@ public class TestWildcardPrivilege {
     Privilege namespace1 = create(new KeyValue("INSTANCE", "instance1"), new KeyValue("NAMESPACE", "namespace1"));
     assertFalse(namespace1.implies(null));
     assertFalse(namespace1.implies(p));
-    assertFalse(namespace1.equals(null));
+    assertNotNull(namespace1);
     assertFalse(namespace1.equals(p));
   }
 


### PR DESCRIPTION
- Creates a dot role and grants `ALL` privileges on it in response to a grant request for a user. 
- This request must follow a successful `create` request on a CDAP entity. Currently the only way to do this is to check that the action requested is `Collections.singleton(Action.ALL)`. However, this needs to be improved in future and made more fool-proof, so a grant request to sentry issued by a user (through CDAP CLI/Client) is not successful.
- Also updated the enforcement code to respect permissions on the hierarchy of an entity.

Build: http://builds.cask.co/browse/CDAP-CSI15
