### PR TITLE
- Use maven-dependency-plugin to copy jars instead of maven-resources-plugin

### DIFF
--- a/cdap-security-extensions-dist/pom.xml
+++ b/cdap-security-extensions-dist/pom.xml
@@ -50,6 +50,29 @@
     <package.sentry.dirs>${package.sentry.libs}/=/opt/${package.sentry.name}/</package.sentry.dirs>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-authorization-dataset-extn</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-sentry-binding</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-sentry-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-sentry-policy</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
   <profiles>
     <profile>
       <id>pkg-prepare</id>
@@ -110,61 +133,56 @@
               </execution>
             </executions>
           </plugin>
+
+          <!-- Use the maven-dependency-plugin to copy dependencies to use while generating packages -->
           <plugin>
-            <artifactId>maven-resources-plugin</artifactId>
-            <version>2.6</version>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <version>2.10</version>
             <executions>
               <execution>
-                <id>copy-cdap-resources</id>
+                <id>copy</id>
                 <phase>validate</phase>
                 <goals>
-                  <goal>copy-resources</goal>
+                  <goal>copy</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>${package.cdap.libs}</outputDirectory>
-                  <resources>
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-sentry/cdap-sentry-binding/target</directory>
-                      <filtering>true</filtering>
-                      <includes>
-                        <include>*.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-authorization-dataset-extn/target</directory>
-                      <filtering>true</filtering>
-                      <includes>
-                        <include>*.jar</include>
-                      </includes>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-              <execution>
-                <id>copy-sentry-resources</id>
-                <!-- here the phase you need -->
-                <phase>validate</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>${package.sentry.libs}</outputDirectory>
-                  <resources>
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-sentry/cdap-sentry-model/target</directory>
-                      <filtering>true</filtering>
-                      <includes>
-                        <include>*.jar</include>
-                      </includes>
-                    </resource>
-                    <resource>
-                      <directory>${project.parent.basedir}/cdap-sentry/cdap-sentry-policy/target</directory>
-                      <filtering>true</filtering>
-                      <includes>
-                        <include>*.jar</include>
-                      </includes>
-                    </resource>
-                  </resources>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>co.cask.cdap</groupId>
+                      <artifactId>cdap-authorization-dataset-extn</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${package.cdap.libs}</outputDirectory>
+                    </artifactItem>
+                    <artifactItem>
+                      <groupId>co.cask.cdap</groupId>
+                      <artifactId>cdap-sentry-binding</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${package.cdap.libs}</outputDirectory>
+                    </artifactItem>
+                    <artifactItem>
+                      <groupId>co.cask.cdap</groupId>
+                      <artifactId>cdap-sentry-model</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${package.sentry.libs}</outputDirectory>
+                    </artifactItem>
+                    <artifactItem>
+                      <groupId>co.cask.cdap</groupId>
+                      <artifactId>cdap-sentry-policy</artifactId>
+                      <version>${project.version}</version>
+                      <type>jar</type>
+                      <overWrite>true</overWrite>
+                      <outputDirectory>${package.sentry.libs}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                  <overWriteReleases>true</overWriteReleases>
+                  <overWriteSnapshots>true</overWriteSnapshots>
                 </configuration>
               </execution>
             </executions>

--- a/cdap-sentry/pom.xml
+++ b/cdap-sentry/pom.xml
@@ -40,51 +40,11 @@
   <description>A CDAP authorization extension using Apache Sentry as the backing store for ACLs.</description>
   <url>http://github.com/caskdata/cdap-security-extn/cdap-sentry</url>
 
-  <organization>
-    <name>Cask Data, Inc.</name>
-    <url>http://cask.co</url>
-  </organization>
-
-  <licenses>
-    <license>
-      <name>The Apache Software License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-    </license>
-  </licenses>
-
-  <developers>
-    <developer>
-      <name>Cask Data</name>
-      <email>cask-dev@googlegroups.com</email>
-      <organization>Cask Data, Inc.</organization>
-      <organizationUrl>http://www.cdap.io</organizationUrl>
-    </developer>
-  </developers>
-
-  <scm>
-    <connection>scm:git:https://github.com/caskdata/cdap-security-extn.git</connection>
-    <developerConnection>scm:git:git@github.com:caskdata/cdap-security-extn.git</developerConnection>
-    <url>https://github.com/caskdata/cdap-security-extn.git</url>
-    <tag>HEAD</tag>
-  </scm>
-
-
   <properties>
     <hadoop.version>2.3.0</hadoop.version>
     <sentry.version>1.7.0</sentry.version>
   </properties>
-
-  <repositories>
-    <repository>
-      <id>sonatype</id>
-      <url>https://oss.sonatype.org/content/groups/public</url>
-    </repository>
-    <repository>
-      <id>sonatype-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </repository>
-  </repositories>
-
+  
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,17 @@
     <junit.version>4.11</junit.version>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/groups/public</url>
+    </repository>
+    <repository>
+      <id>sonatype-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
which seems to be generating garbled jars
- Moved `<repositories>` to top-level so its available for the dataset extension as well. Removed duplicate definitions from cdap-sentry pom, so it can just re-use the ones from the top-level pom.

Build: http://builds.cask.co/browse/CDAP-CSI16
