### PR TITLE
Revert "Add support for listing privileges"

### DIFF
--- a/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizer.java
+++ b/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizer.java
@@ -65,7 +65,7 @@ public class SentryAuthorizer extends AbstractAuthorizer {
       properties.getProperty(AuthConf.SERVICE_INSTANCE_NAME) :
       AuthConf.AuthzConfVars.getDefault(AuthConf.SERVICE_INSTANCE_NAME);
 
-    LOG.info("Configuring SentryAuthorizer with sentry-site.xml at {} and cdap instance name {}",
+    LOG.info("Configuring SentryAuthorizer with sentry-site.xml at {} and cdap instance name {}" +
                sentrySiteUrl, serviceInstanceName);
     this.binding = new AuthBinding(sentrySiteUrl, superUsers, serviceInstanceName);
   }
@@ -96,7 +96,8 @@ public class SentryAuthorizer extends AbstractAuthorizer {
 
   @Override
   public Set<Privilege> listPrivileges(Principal principal) {
-    return binding.listPrivileges(principal);
+    //TODO: Add code here to list privileges
+    return null;
   }
 
   @Override
@@ -107,11 +108,13 @@ public class SentryAuthorizer extends AbstractAuthorizer {
   @Override
   public void dropRole(Role role) throws RoleNotFoundException {
     binding.dropRole(role);
+
   }
 
   @Override
   public void addRoleToPrincipal(Role role, Principal principal) throws RoleNotFoundException {
     binding.addRoleToGroup(role, principal);
+
   }
 
   @Override

--- a/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/conf/AuthConf.java
+++ b/cdap-sentry/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/conf/AuthConf.java
@@ -32,11 +32,11 @@ public class AuthConf extends Configuration {
   // sentry-site.xml path
   public static final String SENTRY_SITE_URL = "sentry.site.url";
   // cdap instance name to be used in sentry for example: cdap
-  public static final String SERVICE_INSTANCE_NAME = "instance.name";
+  public static final String SERVICE_INSTANCE_NAME = "cdap.instance.name";
   // cdap username to be used in sentry for example: cdap
-  public static final String SERVICE_USER_NAME = "user.name";
+  public static final String SERVICE_USER_NAME = "cdap.user.name";
   // a comma separated list of users who will be superusers
-  public static final String SERVICE_SUPERUSERS = "superusers";
+  public static final String SERVICE_SUPERUSERS = "cdap.superusers";
 
   /**
    * Config setting definitions

--- a/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
+++ b/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
@@ -21,33 +21,26 @@ import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
-import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
-import co.cask.cdap.proto.security.Action;
-import co.cask.cdap.proto.security.Privilege;
 import co.cask.cdap.security.authorization.sentry.model.Application;
 import co.cask.cdap.security.authorization.sentry.model.Artifact;
-import co.cask.cdap.security.authorization.sentry.model.Authorizable;
 import co.cask.cdap.security.authorization.sentry.model.Authorizable.AuthorizableType;
 import co.cask.cdap.security.authorization.sentry.model.Dataset;
 import co.cask.cdap.security.authorization.sentry.model.Instance;
 import co.cask.cdap.security.authorization.sentry.model.Namespace;
 import co.cask.cdap.security.authorization.sentry.model.Program;
 import co.cask.cdap.security.authorization.sentry.model.Stream;
-import com.google.common.collect.ImmutableSet;
-import org.apache.sentry.provider.db.generic.service.thrift.TSentryPrivilege;
+import org.apache.sentry.core.common.Authorizable;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Test for {@link AuthBinding#toSentryAuthorizables(EntityId)}. For others please see
+ * Test for {@link AuthBinding#convertEntityToAuthorizables(String, EntityId)}. For others please see
  * {@link SentryAuthorizerTest} since {@link SentryAuthorizer} delegates to {@link AuthBinding}
  */
 public class AuthBindingEntityToAuthMapperTest {
@@ -61,70 +54,38 @@ public class AuthBindingEntityToAuthMapperTest {
   private static final String DATASET = "d1";
   private static final String PROGRAM = "p1";
 
-  private static AuthBinding binding;
-
-  @BeforeClass
-  public static void setup() {
-    URL resource = AuthBindingEntityToAuthMapperTest.class.getClassLoader().getResource("sentry-site.xml");
-    Assert.assertNotNull(resource);
-    String sentrySitePath = resource.getPath();
-    binding = new AuthBinding(sentrySitePath, "superUser", "cdap");
-  }
 
   @Test
   public void testValidEntities() {
-
-    // instance
-    EntityId entityId = new InstanceId(INSTANCE);
-    List<org.apache.sentry.core.common.Authorizable> authorizables = binding.toSentryAuthorizables(entityId);
-    Assert.assertEquals(getAuthorizablesList(AuthorizableType.INSTANCE), authorizables);
-
     // namespace
-    entityId = new NamespaceId(NAMESPACE);
-    authorizables = binding.toSentryAuthorizables(entityId);
+    EntityId entityId = new NamespaceId(NAMESPACE);
+    List<Authorizable> authorizables = AuthBinding.convertEntityToAuthorizables(INSTANCE, entityId);
     Assert.assertEquals(getAuthorizablesList(AuthorizableType.NAMESPACE), authorizables);
 
     // artifact
     entityId = new ArtifactId(NAMESPACE, ARTIFACT, ARTIFACT_VERSION);
-    authorizables = binding.toSentryAuthorizables(entityId);
+    authorizables = AuthBinding.convertEntityToAuthorizables(INSTANCE, entityId);
     Assert.assertEquals(getAuthorizablesList(AuthorizableType.ARTIFACT), authorizables);
 
     // stream
     entityId = new StreamId(NAMESPACE, STREAM);
-    authorizables = binding.toSentryAuthorizables(entityId);
+    authorizables = AuthBinding.convertEntityToAuthorizables(INSTANCE, entityId);
     Assert.assertEquals(getAuthorizablesList(AuthorizableType.STREAM), authorizables);
 
     // dataset
     entityId = new DatasetId(NAMESPACE, DATASET);
-    authorizables = binding.toSentryAuthorizables(entityId);
+    authorizables = AuthBinding.convertEntityToAuthorizables(INSTANCE, entityId);
     Assert.assertEquals(getAuthorizablesList(AuthorizableType.DATASET), authorizables);
 
     // application
     entityId = new ApplicationId(NAMESPACE, APPLICATION);
-    authorizables = binding.toSentryAuthorizables(entityId);
+    authorizables = AuthBinding.convertEntityToAuthorizables(INSTANCE, entityId);
     Assert.assertEquals(getAuthorizablesList(AuthorizableType.APPLICATION), authorizables);
 
     // program
     entityId = new ProgramId(NAMESPACE, APPLICATION, ProgramType.FLOW, PROGRAM);
-    authorizables = binding.toSentryAuthorizables(entityId);
+    authorizables = AuthBinding.convertEntityToAuthorizables(INSTANCE, entityId);
     Assert.assertEquals(getAuthorizablesList(AuthorizableType.PROGRAM), authorizables);
-  }
-
-  @Test
-  public void testToPrivileges() {
-    List<TSentryPrivilege> sentryPrivileges = new LinkedList<>();
-    InstanceId instanceId = new InstanceId(INSTANCE);
-    ArtifactId artifactId = new ArtifactId(NAMESPACE, ARTIFACT, ARTIFACT_VERSION);
-    ProgramId programId = new ProgramId(NAMESPACE, APPLICATION, ProgramType.FLOW, PROGRAM);
-
-    sentryPrivileges.add(binding.toTSentryPrivilege(instanceId, Action.ADMIN));
-    sentryPrivileges.add(binding.toTSentryPrivilege(artifactId, Action.READ));
-    sentryPrivileges.add(binding.toTSentryPrivilege(programId, Action.WRITE));
-
-    Assert.assertEquals(ImmutableSet.of(new Privilege(instanceId, Action.ADMIN),
-                                        new Privilege(artifactId, Action.READ),
-                                        new Privilege(programId, Action.WRITE)),
-                        binding.toPrivileges(sentryPrivileges));
   }
 
   private List<co.cask.cdap.security.authorization.sentry.model.Authorizable> getAuthorizablesList(
@@ -134,19 +95,17 @@ public class AuthBindingEntityToAuthMapperTest {
     return authzList;
   }
 
-  private void getAuthorizablesList(AuthorizableType authzType, List<Authorizable> authorizableList) {
+  private void getAuthorizablesList(
+    AuthorizableType authzType, List<co.cask.cdap.security.authorization.sentry.model.Authorizable> authorizableList) {
     switch (authzType) {
-      case INSTANCE:
+      case NAMESPACE:
         authorizableList.clear();
         authorizableList.add(new Instance(INSTANCE));
-        break;
-      case NAMESPACE:
-        getAuthorizablesList(AuthorizableType.INSTANCE, authorizableList);
         authorizableList.add(new Namespace(NAMESPACE));
         break;
       case ARTIFACT:
         getAuthorizablesList(AuthorizableType.NAMESPACE, authorizableList);
-        authorizableList.add(new Artifact(ARTIFACT, ARTIFACT_VERSION));
+        authorizableList.add(new Artifact(ARTIFACT));
         break;
       case APPLICATION:
         getAuthorizablesList(AuthorizableType.NAMESPACE, authorizableList);
@@ -162,7 +121,7 @@ public class AuthBindingEntityToAuthMapperTest {
         break;
       case PROGRAM:
         getAuthorizablesList(AuthorizableType.APPLICATION, authorizableList);
-        authorizableList.add(new Program(ProgramType.FLOW, PROGRAM));
+        authorizableList.add(new Program(PROGRAM));
         break;
       default:
         throw new IllegalArgumentException(String.format("Authorizable Types %s is invalid.", authzType));

--- a/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
+++ b/cdap-sentry/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
@@ -138,7 +138,7 @@ public class SentryAuthorizerTest {
     testAuthorized(new DatasetId("ns1", "ds1"));
     testAuthorized(new ArtifactId("ns1", "art", "1"));
     testAuthorized(new ApplicationId("ns1", "app1"));
-    testAuthorized(new ProgramId("ns1", "app1", ProgramType.FLOW, "prog1"));
+    testAuthorized(new ProgramId("ns1", "app1", ProgramType.MAPREDUCE, "prog1"));
 
     // admin2 is admin of ns2
     assertAuthorized(new NamespaceId("ns2"), getUser("admin2"), Action.ADMIN);
@@ -146,7 +146,7 @@ public class SentryAuthorizerTest {
     assertAuthorized(new StreamId("ns2", "stream1"), getUser("readers2"), Action.READ);
 
     // executors1 can execute prog1
-    assertAuthorized(new ProgramId("ns1", "app1", ProgramType.FLOW, "prog1"), getUser("executors1"),
+    assertAuthorized(new ProgramId("ns1", "app1", ProgramType.MAPREDUCE, "prog1"), getUser("executors1"),
                      Action.EXECUTE);
   }
 
@@ -174,7 +174,7 @@ public class SentryAuthorizerTest {
   public void testSuperUsers() {
     // hulk being an superuser can do anything
     assertAuthorized(new StreamId("ns2", "stream1"), getUser(SUPERUSER_HULK), Action.READ);
-    assertAuthorized(new ProgramId("ns1", "app1", ProgramType.FLOW, "prog1"), getUser(SUPERUSER_HULK),
+    assertAuthorized(new ProgramId("ns1", "app1", ProgramType.MAPREDUCE, "prog1"), getUser(SUPERUSER_HULK),
                      Action.EXECUTE);
     // and so does spiderman
     assertAuthorized(new StreamId("ns1", "stream1"), getUser(SUPERUSER_SPIDERMAN), Action.READ);

--- a/cdap-sentry/cdap-sentry-binding/src/test/resources/test-authz-provider.ini
+++ b/cdap-sentry/cdap-sentry-binding/src/test/resources/test-authz-provider.ini
@@ -26,12 +26,12 @@ readers2 = readers_ns2stream1
 readers_ns1 = instance=cdap->namespace=ns1->action=read
 writers_ns1 = instance=cdap->namespace=ns1->action=write
 all_ns1 = instance=cdap->namespace=ns1->action=*
-admin_ns1 = instance=cdap->namespace=ns1->action=admin,instance=cdap->namespace=ns1->artifact=art.1->action=admin,instance=cdap->namespace=ns1->stream=stream1->action=admin,instance=cdap->namespace=ns1->application=app1->action=admin,instance=cdap->namespace=ns1->dataset=ds1->action=admin,instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=admin
+admin_ns1 = instance=cdap->namespace=ns1->action=admin,instance=cdap->namespace=ns1->artifact=art->action=admin,instance=cdap->namespace=ns1->stream=stream1->action=admin,instance=cdap->namespace=ns1->application=app1->action=admin,instance=cdap->namespace=ns1->dataset=ds1->action=admin,instance=cdap->namespace=ns1->application=app1->program=prog1->action=admin
 admin_ns2 = instance=cdap->namespace=ns2->action=admin
 ;artifact
-readers_art1 = instance=cdap->namespace=ns1->artifact=art.1->action=read
-writers_art1 = instance=cdap->namespace=ns1->artifact=art.1->action=write
-all_art1 = instance=cdap->namespace=ns1->artifact=art.1->action=*
+readers_art1 = instance=cdap->namespace=ns1->artifact=art->action=read
+writers_art1 = instance=cdap->namespace=ns1->artifact=art->action=write
+all_art1 = instance=cdap->namespace=ns1->artifact=art->action=*
 ;stream
 readers_stream1 = instance=cdap->namespace=ns1->stream=stream1->action=read
 writers_stream1 = instance=cdap->namespace=ns1->stream=stream1->action=write
@@ -46,7 +46,7 @@ readers_app1 = instance=cdap->namespace=ns1->application=app1->action=read
 writers_app1 = instance=cdap->namespace=ns1->application=app1->action=write
 all_app1 = instance=cdap->namespace=ns1->application=app1->action=*
 ;program
-readers_prog1 = instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=read
-writers_prog1 = instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=write
-exec_prog1 = instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=execute
-all_prog1 = instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=*
+readers_prog1 = instance=cdap->namespace=ns1->application=app1->program=prog1->action=read
+writers_prog1 = instance=cdap->namespace=ns1->application=app1->program=prog1->action=write
+exec_prog1 = instance=cdap->namespace=ns1->application=app1->program=prog1->action=execute
+all_prog1 = instance=cdap->namespace=ns1->application=app1->program=prog1->action=*

--- a/cdap-sentry/cdap-sentry-model/pom.xml
+++ b/cdap-sentry/cdap-sentry-model/pom.xml
@@ -43,11 +43,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-proto</artifactId>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/cdap-sentry/cdap-sentry-model/src/main/java/co/cask/cdap/security/authorization/sentry/model/Artifact.java
+++ b/cdap-sentry/cdap-sentry-model/src/main/java/co/cask/cdap/security/authorization/sentry/model/Artifact.java
@@ -16,45 +16,21 @@
 
 package co.cask.cdap.security.authorization.sentry.model;
 
-import co.cask.cdap.api.artifact.ArtifactId;
-import com.google.common.base.Preconditions;
-
 import java.util.Objects;
 
 /**
  * Represents the {@link Authorizable.AuthorizableType#ARTIFACT} authorizable in CDAP
  */
 public class Artifact implements Authorizable {
-
-  private static final String ARTIFACT_DETAILS_SEPARATOR = ".";
-
-  private final String artifactName;
-  private final String artifactVersion;
+  private final String name;
 
   /**
    * Create an {@link Authorizable.AuthorizableType#ARTIFACT} authorizable of the given name.
    *
-   * @param artifactDetails Details of the {@link Authorizable.AuthorizableType#ARTIFACT} which must be in the
-   * following format {@link ArtifactId#name artifactName}.{@link ArtifactId#version artifactVersion}
+   * @param name Name of the {@link Authorizable.AuthorizableType#ARTIFACT}
    */
-  public Artifact(String artifactDetails) {
-    String splitter = "\\" + ARTIFACT_DETAILS_SEPARATOR;
-    String[] artifactNameVersion = artifactDetails.trim().split(splitter, 2);
-    Preconditions.checkArgument(artifactNameVersion.length == 2, "Artifact details %s is invalid. Artifact details " +
-      "must be in the following format: artifactName%sartifactVersion.", artifactDetails, ARTIFACT_DETAILS_SEPARATOR);
-    this.artifactName = artifactNameVersion[0];
-    this.artifactVersion = artifactNameVersion[1];
-  }
-
-  /**
-   * Construct an {@link Authorizable.AuthorizableType#ARTIFACT} authorizable with a known artifact name and version
-   *
-   * @param artifactName the artifact name
-   * @param artifactVersion the artifact version
-   */
-  public Artifact(String artifactName, String artifactVersion) {
-    this.artifactName = artifactName;
-    this.artifactVersion = artifactVersion;
+  public Artifact(String name) {
+    this.name = name;
   }
 
   /**
@@ -68,32 +44,13 @@ public class Artifact implements Authorizable {
   }
 
   /**
-   * Get the artifact details of the {@link Authorizable.AuthorizableType#ARTIFACT} in the following format
-   * {@link ArtifactId#name artifactName}.{@link ArtifactId#version artifactVersion}
+   * Get name of the {@link Authorizable.AuthorizableType#ARTIFACT}.
    *
    * @return Name of the {@link Authorizable.AuthorizableType#ARTIFACT}.
    */
   @Override
   public String getName() {
-    return artifactName + ARTIFACT_DETAILS_SEPARATOR + artifactVersion;
-  }
-
-  /**
-   * Gets name of the {@link Authorizable.AuthorizableType#ARTIFACT}.
-   *
-   * @return name of the {@link Authorizable.AuthorizableType#ARTIFACT}.
-   */
-  public String getArtifactName() {
-    return artifactName;
-  }
-
-  /**
-   * Gets version of the {@link Authorizable.AuthorizableType#ARTIFACT}.
-   *
-   * @return version of the {@link Authorizable.AuthorizableType#ARTIFACT}.
-   */
-  public String getArtifactVersion() {
-    return artifactVersion;
+    return name;
   }
 
   /**
@@ -115,11 +72,11 @@ public class Artifact implements Authorizable {
       return false;
     }
     Artifact that = (Artifact) o;
-    return Objects.equals(artifactName, that.artifactName) && Objects.equals(artifactVersion, that.artifactVersion);
+    return Objects.equals(name, that.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(artifactName, artifactVersion);
+    return Objects.hash(name);
   }
 }

--- a/cdap-sentry/cdap-sentry-model/src/main/java/co/cask/cdap/security/authorization/sentry/model/Program.java
+++ b/cdap-sentry/cdap-sentry-model/src/main/java/co/cask/cdap/security/authorization/sentry/model/Program.java
@@ -16,45 +16,21 @@
 
 package co.cask.cdap.security.authorization.sentry.model;
 
-import co.cask.cdap.proto.ProgramType;
-import com.google.common.base.Preconditions;
-
 import java.util.Objects;
 
 /**
  * Represents the {@link Authorizable.AuthorizableType#PROGRAM} authorizable in CDAP
  */
 public class Program implements Authorizable {
-  private static final String PROGRAM_DETAILS_SEPARATOR = ".";
-
-  private final ProgramType programType;
-  private final String programName;
+  private final String name;
 
   /**
    * Create an {@link Authorizable.AuthorizableType#PROGRAM} authorizable of the given name.
    *
-   * @param programDetails Details of the {@link Authorizable.AuthorizableType#PROGRAM} which should be in the
-   * following format {@link ProgramType programType}.programName
+   * @param name Name of the {@link Authorizable.AuthorizableType#PROGRAM}
    */
-  public Program(String programDetails) {
-    String splitter = "\\" + PROGRAM_DETAILS_SEPARATOR;
-    String[] programTypeAndName = programDetails.trim().split(splitter, 2);
-    Preconditions.checkArgument(
-      programTypeAndName.length == 2, "Program details %s is invalid. Program details must be in the following " +
-        "format: [program-type]%s[program-name].", programTypeAndName, PROGRAM_DETAILS_SEPARATOR);
-    this.programType = ProgramType.valueOfPrettyName(programTypeAndName[0]);
-    this.programName = programTypeAndName[1];
-  }
-
-  /**
-   * Construct a {@link Program} from a known {@link ProgramType} and name
-   *
-   * @param programType the program type
-   * @param programName the program name
-   */
-  public Program(ProgramType programType, String programName) {
-    this.programType = programType;
-    this.programName = programName;
+  public Program(String name) {
+    this.name = name;
   }
 
   /**
@@ -68,32 +44,13 @@ public class Program implements Authorizable {
   }
 
   /**
-   * Get program details of the {@link Authorizable.AuthorizableType#PROGRAM} in the following format
-   * {@link ProgramType programType}.programName
-   *
-   * @return programType.programName of the {@link Authorizable.AuthorizableType#PROGRAM}.
-   */
-  @Override
-  public String getName() {
-    return programType + PROGRAM_DETAILS_SEPARATOR + programName;
-  }
-
-  /**
-   * Get program type of the {@link Authorizable.AuthorizableType#PROGRAM}.
-   *
-   * @return program type of the {@link Authorizable.AuthorizableType#PROGRAM}.
-   */
-  public ProgramType getProgramType() {
-    return programType;
-  }
-
-  /**
    * Get name of the {@link Authorizable.AuthorizableType#PROGRAM}.
    *
    * @return Name of the {@link Authorizable.AuthorizableType#PROGRAM}.
    */
-  public String getProgramName() {
-    return programName;
+  @Override
+  public String getName() {
+    return name;
   }
 
   /**
@@ -115,11 +72,11 @@ public class Program implements Authorizable {
       return false;
     }
     Program that = (Program) o;
-    return Objects.equals(programName, that.programName) && Objects.equals(programType, that.programType);
+    return Objects.equals(name, that.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(programName, programType);
+    return Objects.hash(name);
   }
 }

--- a/cdap-sentry/cdap-sentry-model/src/test/java/co/cask/cdap/security/authorization/sentry/model/TestAuthorizable.java
+++ b/cdap-sentry/cdap-sentry-model/src/test/java/co/cask/cdap/security/authorization/sentry/model/TestAuthorizable.java
@@ -16,7 +16,6 @@
 
 package co.cask.cdap.security.authorization.sentry.model;
 
-import co.cask.cdap.proto.ProgramType;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,33 +30,31 @@ public class TestAuthorizable {
     String name = "test";
 
     Instance instance = new Instance(name);
-    Assert.assertEquals(name, instance.getName());
-    Assert.assertEquals(Authorizable.AuthorizableType.INSTANCE, instance.getAuthzType());
+    Assert.assertEquals(instance.getName(), name);
+    Assert.assertEquals(instance.getAuthzType(), Authorizable.AuthorizableType.INSTANCE);
 
     Namespace namespace = new Namespace(name);
-    Assert.assertEquals(name, namespace.getName());
-    Assert.assertEquals(Authorizable.AuthorizableType.NAMESPACE, namespace.getAuthzType());
+    Assert.assertEquals(namespace.getName(), name);
+    Assert.assertEquals(namespace.getAuthzType(), Authorizable.AuthorizableType.NAMESPACE);
 
-    Artifact artifact = new Artifact("art", "1");
-    Assert.assertEquals("art", artifact.getArtifactName());
-    Assert.assertEquals("1", artifact.getArtifactVersion());
-    Assert.assertEquals(Authorizable.AuthorizableType.ARTIFACT, artifact.getAuthzType());
+    Artifact artifact = new Artifact(name);
+    Assert.assertEquals(artifact.getName(), name);
+    Assert.assertEquals(artifact.getAuthzType(), Authorizable.AuthorizableType.ARTIFACT);
 
     Application application = new Application(name);
-    Assert.assertEquals(name, application.getName());
-    Assert.assertEquals(Authorizable.AuthorizableType.APPLICATION, application.getAuthzType());
+    Assert.assertEquals(application.getName(), name);
+    Assert.assertEquals(application.getAuthzType(), Authorizable.AuthorizableType.APPLICATION);
 
-    Program program = new Program(ProgramType.FLOW, "flow1");
-    Assert.assertEquals(ProgramType.FLOW, program.getProgramType());
-    Assert.assertEquals("flow1", program.getProgramName());
-    Assert.assertEquals(Authorizable.AuthorizableType.PROGRAM, program.getAuthzType());
+    Program program = new Program(name);
+    Assert.assertEquals(program.getName(), name);
+    Assert.assertEquals(program.getAuthzType(), Authorizable.AuthorizableType.PROGRAM);
 
     Stream stream = new Stream(name);
-    Assert.assertEquals(name, stream.getName());
-    Assert.assertEquals(Authorizable.AuthorizableType.STREAM, stream.getAuthzType());
+    Assert.assertEquals(stream.getName(), name);
+    Assert.assertEquals(stream.getAuthzType(), Authorizable.AuthorizableType.STREAM);
 
     Dataset dataset = new Dataset(name);
-    Assert.assertEquals(name, dataset.getName());
-    Assert.assertEquals(Authorizable.AuthorizableType.DATASET, dataset.getAuthzType());
+    Assert.assertEquals(dataset.getName(), name);
+    Assert.assertEquals(dataset.getAuthzType(), Authorizable.AuthorizableType.DATASET);
   }
 }

--- a/cdap-sentry/cdap-sentry-policy/pom.xml
+++ b/cdap-sentry/cdap-sentry-policy/pom.xml
@@ -49,10 +49,5 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-proto</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/cdap-sentry/cdap-sentry-policy/src/main/java/co/cask/cdap/security/authorization/sentry/policy/ModelAuthorizables.java
+++ b/cdap-sentry/cdap-sentry-policy/src/main/java/co/cask/cdap/security/authorization/sentry/policy/ModelAuthorizables.java
@@ -32,21 +32,9 @@ import java.util.NoSuchElementException;
 /**
  * Class to create {@link Authorizable} from {@link AuthorizableType} and name
  */
-public final class ModelAuthorizables {
+final class ModelAuthorizables {
 
   private ModelAuthorizables() {
-  }
-
-  /**
-   * Gets a {@link Authorizable} from the given key and value
-   *
-   * @param key the {@link AuthorizableType type} of the authorizable
-   * @param value the {@link Authorizable name} of the authorizable
-   * @return the created {@link Authorizable} with the given name if {@link AuthorizableType} given was valid
-   * @throws NoSuchElementException if the given {@link AuthorizableType} was not valid
-   */
-  public static Authorizable from(String key, String value) {
-    return from(new KeyValue(key, value));
   }
 
   /**
@@ -57,7 +45,7 @@ public final class ModelAuthorizables {
    * @return the created {@link Authorizable} with the given name if {@link AuthorizableType} given was valid
    * @throws NoSuchElementException if the given {@link AuthorizableType} was not valid
    */
-  static Authorizable from(String keyValue) {
+  public static Authorizable from(String keyValue) {
     return from(new KeyValue(keyValue));
   }
 

--- a/cdap-sentry/cdap-sentry-policy/src/test/java/co/cask/cdap/security/authorization/sentry/policy/TestPrivilegeValidator.java
+++ b/cdap-sentry/cdap-sentry-policy/src/test/java/co/cask/cdap/security/authorization/sentry/policy/TestPrivilegeValidator.java
@@ -50,7 +50,7 @@ public class TestPrivilegeValidator {
     testValidPrivilege("instance=instance1->namespace=namespace1->action=read");
 
     // artifact
-    testValidPrivilege("instance=instance1->namespace=namespace1->artifact=artifact1.0->action=write");
+    testValidPrivilege("instance=instance1->namespace=namespace1->artifact=artifact1->action=write");
 
     // stream
     testValidPrivilege("instance=instance1->namespace=namespace1->stream=stream1->action=all");
@@ -62,7 +62,7 @@ public class TestPrivilegeValidator {
     testValidPrivilege("instance=instance1->namespace=namespace1->application=application1->action=read");
 
     // program
-    testValidPrivilege("instance=instance1->namespace=namespace1->application=application1->program=flow.program1" +
+    testValidPrivilege("instance=instance1->namespace=namespace1->application=application1->program=program1" +
                          "->action=execute");
 
   }
@@ -76,7 +76,7 @@ public class TestPrivilegeValidator {
     testInvalidPrivileges("instance=instance1->namesSpace=namespace1->action=read");
 
     // artifact
-    testInvalidPrivileges("instance=instance1->namespace=namespace1->artTifact=arttifact1.0->action=write");
+    testInvalidPrivileges("instance=instance1->namespace=namespace1->artTifact=arttifact1->action=write");
 
     // stream
     testInvalidPrivileges("instance=instance1->namespace=namespace1->streEam=stream1->action=all");
@@ -88,8 +88,8 @@ public class TestPrivilegeValidator {
     testInvalidPrivileges("instance=instance1->namespace=namespace1->appliCcation=application1->action=read");
 
     // program
-    testInvalidPrivileges("instance=instance1->namespace=namespace1->application=application1->progGram=flow." +
-                            "program1->action=execute");
+    testInvalidPrivileges("instance=instance1->namespace=namespace1->application=application1->progGram=program1" +
+                            "->action=execute");
   }
 
   @Test
@@ -104,8 +104,7 @@ public class TestPrivilegeValidator {
 
   @Test
   public void testWithMorePartsInPrivilege() {
-    testInvalidPrivileges("instance=instance1->namespace=namespace1->dataset=dataset1->program=flow." +
-                            "program1->action=read");
+    testInvalidPrivileges("instance=instance1->namespace=namespace1->dataset=dataset1->program=program1->action=read");
   }
 
   @Test
@@ -126,7 +125,7 @@ public class TestPrivilegeValidator {
       privilegeValidator.validate(new PrivilegeValidatorContext(privilege));
       Assert.fail("Should throw an exception");
     } catch (Exception e) {
-      // expected
+      Assert.assertTrue(e instanceof RuntimeException);
     }
   }
 }

--- a/cdap-sentry/pom.xml
+++ b/cdap-sentry/pom.xml
@@ -88,18 +88,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>co.cask.cdap</groupId>
-        <artifactId>cdap-security-spi</artifactId>
-        <version>${cdap.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>co.cask.cdap</groupId>
-        <artifactId>cdap-proto</artifactId>
-        <version>${cdap.version}</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>


### PR DESCRIPTION
Reverts caskdata/cdap-security-extn#22

Reverting because merging `release/0.1.0` to `develop` is creating a lot of unnecessary conflicts because of this (even via the command line)
