### PR TITLE
Added new enforcement/filtering methods. Refactored AuthBinding to on…

### DIFF
--- a/cdap-authorization-dataset-extn/pom.xml
+++ b/cdap-authorization-dataset-extn/pom.xml
@@ -77,6 +77,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>co.cask.cdap</groupId>
+      <artifactId>cdap-common</artifactId>
+      <version>${cdap.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
@@ -71,8 +71,7 @@ public class AuthBindingEntityToAuthMapperTest {
     URL resource = AuthBindingEntityToAuthMapperTest.class.getClassLoader().getResource("sentry-site.xml");
     Assert.assertNotNull(resource);
     String sentrySitePath = resource.getPath();
-    Set<Principal> superUsers = Collections.singleton(new Principal("superUser", Principal.PrincipalType.USER));
-    binding = new AuthBinding(sentrySitePath, superUsers, "cdap");
+    binding = new AuthBinding(sentrySitePath, "cdap");
   }
 
   @Test

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
@@ -145,7 +145,7 @@ public class SentryAuthorizerTest {
   }
 
   @Test
-  public void testAuthorized() {
+  public void testAuthorized() throws Exception {
     testAuthorized(new NamespaceId("ns1"));
     testAuthorized(new StreamId("ns1", "stream1"));
     testAuthorized(new DatasetId("ns1", "ds1"));
@@ -164,7 +164,7 @@ public class SentryAuthorizerTest {
   }
 
   @Test
-  public void testUnauthorized() {
+  public void testUnauthorized() throws Exception {
     // do some invalid operations
     // admin1 is not admin of ns2
     assertUnauthorized(new NamespaceId("ns2"), getUser("admin1"), Action.ADMIN);
@@ -184,7 +184,7 @@ public class SentryAuthorizerTest {
   }
 
   @Test
-  public void testSuperUsers() {
+  public void testSuperUsers() throws Exception {
     // hulk being an superuser can do anything
     assertAuthorized(new StreamId("ns2", "stream1"), getUser(SUPERUSER_HULK), Action.READ);
     assertAuthorized(new ProgramId("ns1", "app1", ProgramType.FLOW, "prog1"), getUser(SUPERUSER_HULK),
@@ -195,7 +195,7 @@ public class SentryAuthorizerTest {
   }
 
   @Test
-  public void testHierarchy() {
+  public void testHierarchy() throws Exception {
     // admin1 has ADMIN on ns1
     assertAuthorized(new NamespaceId("ns1"), getUser("admin1"), Action.ADMIN);
     // hence, admin1 should have ADMIN on any child of ns1, even a child that admin1 has not been given explicit ADMIN
@@ -221,7 +221,7 @@ public class SentryAuthorizerTest {
                      getUser("readers1"), Action.READ);
   }
 
-  private void testAuthorized(EntityId entityId) {
+  private void testAuthorized(EntityId entityId) throws Exception {
     // admin1 is admin of entity
     assertAuthorized(entityId, getUser("admin1"), Action.ADMIN);
     // reader1 can read entity
@@ -234,7 +234,7 @@ public class SentryAuthorizerTest {
     assertAuthorized(entityId, getUser("all1"), Action.ADMIN);
   }
 
-  private void assertAuthorized(EntityId entityId, Principal principal, Action action) {
+  private void assertAuthorized(EntityId entityId, Principal principal, Action action) throws Exception {
     try {
       authorizer.enforce(entityId, principal, action);
     } catch (UnauthorizedException e) {
@@ -242,7 +242,7 @@ public class SentryAuthorizerTest {
     }
   }
 
-  private void assertUnauthorized(EntityId entityId, Principal principal, Action action) {
+  private void assertUnauthorized(EntityId entityId, Principal principal, Action action) throws Exception {
     try {
       authorizer.enforce(entityId, principal, action);
       Assert.fail("The authorization check should have failed.");


### PR DESCRIPTION
…ly have code that requires communication with Sentry

Build: http://builds.cask.co/browse/CDAP-CSI20 - Red right now because CDAP snapshots have not yet been published, but passes locally.
