### PR TITLE
CDAP-6832 Update README for Sentry version

### DIFF
--- a/cdap-sentry/cdap-sentry-extension/README.rst
+++ b/cdap-sentry/cdap-sentry-extension/README.rst
@@ -38,9 +38,11 @@ Building
 
 Prerequisites
 -------------
-Since Apache Sentry releases are source-only, this project assumes that Sentry has been pre-built and installed in the
-local maven repo. To do this, in the Apache Sentry source root directory please run::
+Since Apache Sentry releases are source-only, this project assumes that Apache Sentry 1.7.0 has been pre-built and
+installed in the local maven repo. To do this, in the Apache Sentry source root directory please run::
 
+  git fetch origin
+  git checkout branch-1.7.0
   mvn clean install -DskipTests
 
 


### PR DESCRIPTION
Updated with the version of Apache Sentry that this package needs and instructions on making sure that the user is on the correct branch. Fixes CDAP-6832
