### PR TITLE
Disable dataset based authorization extension since it creates a circ…

### DIFF
--- a/cdap-security-extensions-dist/pom.xml
+++ b/cdap-security-extensions-dist/pom.xml
@@ -53,11 +53,6 @@
   <dependencies>
     <dependency>
       <groupId>co.cask.cdap</groupId>
-      <artifactId>cdap-authorization-dataset-extn</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.cdap</groupId>
       <artifactId>cdap-sentry-binding</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -148,14 +143,6 @@
                 </goals>
                 <configuration>
                   <artifactItems>
-                    <artifactItem>
-                      <groupId>co.cask.cdap</groupId>
-                      <artifactId>cdap-authorization-dataset-extn</artifactId>
-                      <version>${project.version}</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <outputDirectory>${package.cdap.libs}</outputDirectory>
-                    </artifactItem>
                     <artifactItem>
                       <groupId>co.cask.cdap</groupId>
                       <artifactId>cdap-sentry-binding</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
 
   <modules>
     <module>cdap-sentry</module>
-    <module>cdap-authorization-dataset-extn</module>
     <module>cdap-security-extensions-dist</module>
   </modules>
 


### PR DESCRIPTION
…ular dependency. An entity on which authorization should be enforced (CDAP Dataset) shouldn't be the backend for authorization.