### PR TITLE
Merge/release/0.2

### DIFF
--- a/cdap-sentry/cdap-hue-extension/pom.xml
+++ b/cdap-sentry/cdap-hue-extension/pom.xml
@@ -26,7 +26,6 @@
   </parent>
 
   <artifactId>cdap-hue-extension</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 

--- a/cdap-sentry/cdap-sentry-extension/pom.xml
+++ b/cdap-sentry/cdap-sentry-extension/pom.xml
@@ -26,7 +26,6 @@
   </parent>
 
   <artifactId>cdap-sentry-extension</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
 
   <modules>
     <module>cdap-sentry-model</module>

--- a/cdap-sentry/pom.xml
+++ b/cdap-sentry/pom.xml
@@ -26,7 +26,6 @@
   </parent>
 
   <artifactId>cdap-sentry</artifactId>
-  <version>0.3.0-SNAPSHOT</version>
 
   <modules>
     <module>cdap-sentry-extension</module>


### PR DESCRIPTION
conflicts in some pom.xmls, where some redundant version definitions were removed in the release/0.2 branch. This PR removes them from develop as well.