### PR TITLE
Add distributionManagement for deploy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,21 @@
     </repository>
   </repositories>
 
+  <distributionManagement>
+    <repository>
+      <id>sonatype.release</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype.snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <site>
+      <id>cask</id>
+      <url>http://cask.co</url>
+    </site>
+  </distributionManagement>
+
   <dependencyManagement>
     <dependencies>
       <dependency>


### PR DESCRIPTION
This allows this repository to be included in a `mvn deploy` build using `cdap-build` with this repository as a submodule.
