### PR TITLE
CDAP-7680 Fix revoke on entity also used to revoke while deleting ent…

### DIFF
--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/AuthBinding.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/AuthBinding.java
@@ -79,7 +79,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -558,18 +557,15 @@ class AuthBinding {
 
   @VisibleForTesting
   TSentryPrivilege toTSentryPrivilege(EntityId entityId, Action action) {
-    List<org.apache.sentry.core.common.Authorizable> authorizables = toSentryAuthorizables(entityId);
-    List<TAuthorizable> tAuthorizables = new ArrayList<>();
-    for (org.apache.sentry.core.common.Authorizable authorizable : authorizables) {
-      tAuthorizables.add(new TAuthorizable(authorizable.getTypeName(), authorizable.getName()));
-    }
+    List<TAuthorizable> tAuthorizables = toTAuthorizable(entityId);
     return new TSentryPrivilege(COMPONENT_NAME, instanceName, tAuthorizables, action.name());
   }
 
   private List<TAuthorizable> toTAuthorizable(EntityId entityId) {
+    List<org.apache.sentry.core.common.Authorizable> authorizables = toSentryAuthorizables(entityId);
     List<TAuthorizable> tAuthorizables = new ArrayList<>();
-    for (Action action : EnumSet.allOf(Action.class)) {
-      tAuthorizables.addAll(toTSentryPrivilege(entityId, action).getAuthorizables());
+    for (org.apache.sentry.core.common.Authorizable authorizable : authorizables) {
+      tAuthorizables.add(new TAuthorizable(authorizable.getTypeName(), authorizable.getName()));
     }
     return tAuthorizables;
   }


### PR DESCRIPTION
…ities

Revoke on entities broke while removing support for ALL action in here https://github.com/caskdata/cdap-security-extn/pull/72 which was because the authorizatable were being added to the tAuthorizables 4 times (the number of actions we have) and equals was failing. 

This will also fix the issue where delete of entities was not deleting the privileges since delete entities calls revoke on entity. 

Issue: https://issues.cask.co/browse/CDAP-7680
Build: https://builds.cask.co/browse/CDAP-CSI37-1