### PR TITLE
Bumping develop version to 0.5.0-SNAPSHOT

### DIFF
--- a/cdap-security-extensions-dist/pom.xml
+++ b/cdap-security-extensions-dist/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-security-extensions</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>

--- a/cdap-sentry/cdap-hue-extension/pom.xml
+++ b/cdap-sentry/cdap-hue-extension/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-sentry</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-hue-extension</artifactId>

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/pom.xml
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-sentry-extension</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-model/pom.xml
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-model/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-sentry-extension</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-policy/pom.xml
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-policy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>cdap-sentry-extension</artifactId>
     <groupId>co.cask.cdap</groupId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/cdap-sentry/cdap-sentry-extension/pom.xml
+++ b/cdap-sentry/cdap-sentry-extension/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-sentry</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-sentry-extension</artifactId>

--- a/cdap-sentry/pom.xml
+++ b/cdap-sentry/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-security-extensions</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>cdap-sentry</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>co.cask.cdap</groupId>
   <artifactId>cdap-security-extensions</artifactId>
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.5.0-SNAPSHOT</version>
 
   <modules>
     <module>cdap-sentry</module>


### PR DESCRIPTION
Same as https://github.com/caskdata/cdap-security-extn/pull/100, but against develop branch.