### PR TITLE
Replace deprecated method.

### DIFF
--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/AuthBinding.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/AuthBinding.java
@@ -690,7 +690,7 @@ class AuthBinding {
    * add authorizables to
    */
   private void toAuthorizables(EntityId entityId, List<org.apache.sentry.core.common.Authorizable> authorizables) {
-    EntityType entityType = entityId.getEntity();
+    EntityType entityType = entityId.getEntityType();
     switch (entityType) {
       case INSTANCE:
         authorizables.add(new Instance(((InstanceId) entityId).getInstance()));


### PR DESCRIPTION
Replace the deprecated method `EntityId#getEntity` method.