### PR TITLE
Revert "CDAP-11792 Do not propagate instance privileges"

### DIFF
--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/AuthBinding.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/main/java/co/cask/cdap/security/authorization/sentry/binding/AuthBinding.java
@@ -701,7 +701,7 @@ class AuthBinding {
         authorizables.add(new Instance(((InstanceId) entityId).getInstance()));
         break;
       case NAMESPACE:
-        authorizables.add(new Instance(encodeInstance(instanceName)));
+        toAuthorizables(new InstanceId(instanceName), authorizables);
         authorizables.add(new Namespace(((NamespaceId) entityId).getNamespace()));
         break;
       case ARTIFACT:
@@ -747,16 +747,5 @@ class AuthBinding {
       default:
         throw new IllegalArgumentException(String.format("The entity %s is of unknown type %s", entityId, entityType));
     }
-  }
-
-  /**
-   * Encodes the instanceName by adding 1 as the first character to the given instanceName.
-   * This is done so that the privileges on the instance is not propagated to namespace. See CDAP-11792 for details
-   *
-   * @param instanceName the instanceName that needs to be encoded
-   * @return an encoded instanceName
-   */
-  private String encodeInstance(String instanceName) {
-    return "1" + instanceName;
   }
 }

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
@@ -165,8 +165,7 @@ public class AuthBindingEntityToAuthMapperTest {
         authorizableList.add(new Instance(INSTANCE));
         break;
       case NAMESPACE:
-        // we add 1 here since instance will be encoded
-        authorizableList.add(new Instance("1" + INSTANCE));
+        getAuthorizablesList(AuthorizableType.INSTANCE, authorizableList);
         authorizableList.add(new Namespace(NAMESPACE));
         break;
       case ARTIFACT:

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
@@ -30,7 +30,6 @@ import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.ArtifactId;
 import co.cask.cdap.proto.id.DatasetId;
 import co.cask.cdap.proto.id.EntityId;
-import co.cask.cdap.proto.id.InstanceId;
 import co.cask.cdap.proto.id.NamespaceId;
 import co.cask.cdap.proto.id.ProgramId;
 import co.cask.cdap.proto.id.StreamId;
@@ -38,8 +37,10 @@ import co.cask.cdap.proto.security.Action;
 import co.cask.cdap.proto.security.Principal;
 import co.cask.cdap.security.authorization.sentry.binding.conf.AuthConf;
 import co.cask.cdap.security.spi.authorization.AuthorizationContext;
+import co.cask.cdap.security.spi.authorization.RoleNotFoundException;
 import co.cask.cdap.security.spi.authorization.UnauthorizedException;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
 import org.apache.tephra.TransactionFailureException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -234,9 +235,6 @@ public class SentryAuthorizerTest {
   @Test
   public void testUnauthorized() throws Exception {
     // do some invalid operations
-    // instance_admin1 should not be able to read the stream inside the instance even though he has read on the
-    // instance
-    assertUnauthorized(new StreamId("ns1", "stream1"), getUser("instance_admin1"), Action.READ);
     // admin1 is not admin of ns2
     assertUnauthorized(new NamespaceId("ns2"), getUser("admin1"), Action.ADMIN);
 
@@ -255,8 +253,6 @@ public class SentryAuthorizerTest {
 
   @Test
   public void testHierarchy() throws Exception {
-    // instance_admin1 should be able to read the instance
-    assertAuthorized(new InstanceId("cdap"), getUser("instance_admin1"), Action.READ);
     // admin1 has ADMIN on ns1
     assertAuthorized(new NamespaceId("ns1"), getUser("admin1"), Action.ADMIN);
     // hence, admin1 should have ADMIN on any child of ns1, even a child that admin1 has not been given explicit ADMIN

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/resources/test-authz-provider.ini
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/resources/test-authz-provider.ini
@@ -13,7 +13,6 @@
 # the License.
 
 [groups]
-instance_admin1 = instance_cdap
 readers1 = readers_ns1, readers_art1, readers_stream1, readers_ds1, readers_app1, readers_prog1
 writers1 = writers_ns1, writers_art1, writers_stream1, writers_ds1, writers_app1, writers_prog1
 all1 = all_ns1, all_art1, all_stream1, all_ds1, all_app1, all_prog1
@@ -23,33 +22,31 @@ admin2 = admin_ns2
 readers2 = readers_ns2stream1
 
 [roles]
-; instance
-instance_cdap = instance=cdap->action=read
 ; namespace
-readers_ns1 = instance=1cdap->namespace=ns1->action=read
-writers_ns1 = instance=1cdap->namespace=ns1->action=write
-all_ns1 = instance=1cdap->namespace=ns1->action=all
-admin_ns1 = instance=1cdap->namespace=ns1->action=admin,instance=1cdap->namespace=ns1->artifact=art.1->action=admin,instance=1cdap->namespace=ns1->stream=stream1->action=admin,instance=1cdap->namespace=ns1->application=app1->action=admin,instance=1cdap->namespace=ns1->dataset=ds1->action=admin,instance=1cdap->namespace=ns1->application=app1->program=flow.prog1->action=admin
-admin_ns2 = instance=1cdap->namespace=ns2->action=admin
+readers_ns1 = instance=cdap->namespace=ns1->action=read
+writers_ns1 = instance=cdap->namespace=ns1->action=write
+all_ns1 = instance=cdap->namespace=ns1->action=all
+admin_ns1 = instance=cdap->namespace=ns1->action=admin,instance=cdap->namespace=ns1->artifact=art.1->action=admin,instance=cdap->namespace=ns1->stream=stream1->action=admin,instance=cdap->namespace=ns1->application=app1->action=admin,instance=cdap->namespace=ns1->dataset=ds1->action=admin,instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=admin
+admin_ns2 = instance=cdap->namespace=ns2->action=admin
 ;artifact
-readers_art1 = instance=1cdap->namespace=ns1->artifact=art.1->action=read
-writers_art1 = instance=1cdap->namespace=ns1->artifact=art.1->action=write
-all_art1 = instance=1cdap->namespace=ns1->artifact=art.1->action=all
+readers_art1 = instance=cdap->namespace=ns1->artifact=art.1->action=read
+writers_art1 = instance=cdap->namespace=ns1->artifact=art.1->action=write
+all_art1 = instance=cdap->namespace=ns1->artifact=art.1->action=all
 ;stream
-readers_stream1 = instance=1cdap->namespace=ns1->stream=stream1->action=read
-writers_stream1 = instance=1cdap->namespace=ns1->stream=stream1->action=write
-all_stream1 = instance=1cdap->namespace=ns1->stream=stream1->action=all
-readers_ns2stream1 = instance=1cdap->namespace=ns2->stream=stream1->action=read
+readers_stream1 = instance=cdap->namespace=ns1->stream=stream1->action=read
+writers_stream1 = instance=cdap->namespace=ns1->stream=stream1->action=write
+all_stream1 = instance=cdap->namespace=ns1->stream=stream1->action=all
+readers_ns2stream1 = instance=cdap->namespace=ns2->stream=stream1->action=read
 ;dataset
-readers_ds1 = instance=1cdap->namespace=ns1->dataset=ds1->action=read
-writers_ds1 = instance=1cdap->namespace=ns1->dataset=ds1->action=write
-all_ds1 = instance=1cdap->namespace=ns1->dataset=ds1->action=all
+readers_ds1 = instance=cdap->namespace=ns1->dataset=ds1->action=read
+writers_ds1 = instance=cdap->namespace=ns1->dataset=ds1->action=write
+all_ds1 = instance=cdap->namespace=ns1->dataset=ds1->action=all
 ;application
-readers_app1 = instance=1cdap->namespace=ns1->application=app1->action=read
-writers_app1 = instance=1cdap->namespace=ns1->application=app1->action=write
-all_app1 = instance=1cdap->namespace=ns1->application=app1->action=all
+readers_app1 = instance=cdap->namespace=ns1->application=app1->action=read
+writers_app1 = instance=cdap->namespace=ns1->application=app1->action=write
+all_app1 = instance=cdap->namespace=ns1->application=app1->action=all
 ;program
-readers_prog1 = instance=1cdap->namespace=ns1->application=app1->program=flow.prog1->action=read
-writers_prog1 = instance=1cdap->namespace=ns1->application=app1->program=flow.prog1->action=write
-exec_prog1 = instance=1cdap->namespace=ns1->application=app1->program=flow.prog1->action=execute
-all_prog1 = instance=1cdap->namespace=ns1->application=app1->program=flow.prog1->action=all
+readers_prog1 = instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=read
+writers_prog1 = instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=write
+exec_prog1 = instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=execute
+all_prog1 = instance=cdap->namespace=ns1->application=app1->program=flow.prog1->action=all


### PR DESCRIPTION
Reverts caskdata/cdap-security-extn#120

This change is no longer needed as the implementation of enforcing privileges has changed in https://github.com/caskdata/cdap-security-extn/pull/123, such that we no longer rely on Sentry's `hasAccess`, which was allowing access due to hierarchical privileges.

Reverting this change also removes the need for an upgrade step.