### PR TITLE
CDAP-12135 Change caching model to reduce memory usage by avoiding denormalized caching

### DIFF
--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/AuthBindingEntityToAuthMapperTest.java
@@ -77,7 +77,7 @@ public class AuthBindingEntityToAuthMapperTest {
     URL resource = AuthBindingEntityToAuthMapperTest.class.getClassLoader().getResource("sentry-site.xml");
     Assert.assertNotNull(resource);
     String sentrySitePath = resource.getPath();
-    binding = new AuthBinding(sentrySitePath, "cdap", null);
+    binding = new AuthBinding(sentrySitePath, "cdap", null, 60, 100);
   }
 
   @Test

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/test/java/co/cask/cdap/security/authorization/sentry/binding/SentryAuthorizerTest.java
@@ -275,30 +275,6 @@ public class SentryAuthorizerTest {
     assertUnauthorized(new StreamId("ns1", "stream1"), getUser("admin1"), Action.EXECUTE);
   }
 
-  @Test
-  public void testCache() throws Exception {
-    NamespaceId ns1 = new NamespaceId("ns1");
-    Principal executors1 = getUser("executors1");
-    Principal admin1 = getUser("admin1");
-
-    assertUnauthorized(ns1, executors1, Action.READ);
-    assertAuthorized(ns1, admin1, Action.ADMIN);
-
-    Assert.assertEquals(2,  authorizer.cacheAsMap().size());
-    Assert.assertTrue(authorizer.cacheAsMap().containsKey(executors1));
-    Assert.assertTrue(authorizer.cacheAsMap().containsKey(admin1));
-
-    Assert.assertTrue(authorizer.cacheAsMap().containsKey(executors1));
-    Assert.assertTrue(authorizer.cacheAsMap().containsKey(admin1));
-    TimeUnit.SECONDS.sleep(CACHE_TTL_SECS);
-    // test TTL-eviction
-    Assert.assertFalse(authorizer.cacheAsMap().containsKey(executors1));
-    Assert.assertFalse(authorizer.cacheAsMap().containsKey(admin1));
-
-    assertUnauthorized(ns1, admin1, Action.READ);
-    Assert.assertTrue(authorizer.cacheAsMap().containsKey(admin1));
-  }
-
   private void testAuthorized(EntityId entityId) throws Exception {
     // admin1 is admin of entity
     assertAuthorized(entityId, getUser("admin1"), Action.ADMIN);


### PR DESCRIPTION
The idea is to replace one big cache of `Principal, Entity, Action] -> Boolean` with three smaller caches - group cache, role cache and entity-actions cache. This is so that we avoid caching duplicate entries (entity/aciton) for every principal belonging to the same role.

Note: the entity-actions cache will be replaced by a wildcard policy cache in the up-coming PR.

Build - https://builds.cask.co/browse/CDAP-CSI58-5
