### PR TITLE
CDAP-12148 Add test for RangerAuthorizer

### DIFF
--- a/cdap-ranger/cdap-ranger-binding/pom.xml
+++ b/cdap-ranger/cdap-ranger-binding/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>cdap-ranger-common</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/cdap-ranger/cdap-ranger-binding/src/main/java/co/cask/cdap/security/authorization/ranger/binding/RangerAuthorizer.java
+++ b/cdap-ranger/cdap-ranger-binding/src/main/java/co/cask/cdap/security/authorization/ranger/binding/RangerAuthorizer.java
@@ -207,8 +207,6 @@ public class RangerAuthorizer extends AbstractAuthorizer {
     RangerAccessResourceImpl rangerResource = new RangerAccessResourceImpl();
     rangerRequest.setResource(rangerResource);
     rangerRequest.setAccessType(accessType);
-    rangerRequest.setAction(accessType);
-    rangerRequest.setRequestData(entity.toString());
 
     setAccessResource(entity, rangerResource);
 
@@ -284,7 +282,7 @@ public class RangerAuthorizer extends AbstractAuthorizer {
       case PROGRAM:
         ProgramId programId = (ProgramId) entityId;
         setAccessResource(programId.getParent(), rangerAccessResource);
-        rangerAccessResource.setValue(RangerCommon.KEY_PROGRAM, programId.getType() +
+        rangerAccessResource.setValue(RangerCommon.KEY_PROGRAM, programId.getType().getPrettyName().toLowerCase() +
           RangerCommon.RESOURCE_SEPARATOR + programId.getProgram());
         break;
       case SECUREKEY:

--- a/cdap-ranger/cdap-ranger-binding/src/test/java/co/cask/cdap/security/authorization/ranger/binding/InMemoryAuthorizationContext.java
+++ b/cdap-ranger/cdap-ranger-binding/src/test/java/co/cask/cdap/security/authorization/ranger/binding/InMemoryAuthorizationContext.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.security.authorization.ranger.binding;
+
+import co.cask.cdap.api.TxRunnable;
+import co.cask.cdap.api.data.DatasetInstantiationException;
+import co.cask.cdap.api.dataset.Dataset;
+import co.cask.cdap.api.dataset.DatasetManagementException;
+import co.cask.cdap.api.dataset.DatasetProperties;
+import co.cask.cdap.api.dataset.InstanceNotFoundException;
+import co.cask.cdap.api.messaging.TopicAlreadyExistsException;
+import co.cask.cdap.api.messaging.TopicNotFoundException;
+import co.cask.cdap.api.security.store.SecureStoreData;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authorization.AuthorizationContext;
+import org.apache.tephra.TransactionFailureException;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+
+/**
+ * Dummy implementation of AuthorizationContext for {@link RangerAuthorizerTest}
+ */
+public class InMemoryAuthorizationContext implements AuthorizationContext {
+  private final Properties properties = new Properties();
+
+  @Override
+  public Map<String, String> listSecureData(String namespace) throws Exception {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public SecureStoreData getSecureData(String namespace, String name) throws Exception {
+    throw new NoSuchElementException(namespace + ":" + name);
+  }
+
+  @Override
+  public void putSecureData(String namespace, String key, String data, String description,
+                            Map<String, String> properties) throws IOException {
+    // no-op
+  }
+
+  @Override
+  public void deleteSecureData(String namespace, String key) throws IOException {
+    // no-op
+  }
+
+  @Override
+  public Principal getPrincipal() {
+    return new Principal(System.getProperty("cdap"), Principal.PrincipalType.USER);
+  }
+
+  @Override
+  public Properties getExtensionProperties() {
+    return properties;
+  }
+
+  @Override
+  public void createTopic(String topic) throws TopicAlreadyExistsException, IOException {
+    // no-op
+  }
+
+  @Override
+  public void createTopic(String topic,
+                          Map<String, String> properties) throws TopicAlreadyExistsException, IOException {
+    // no-op
+  }
+
+  @Override
+  public Map<String, String> getTopicProperties(String topic) throws TopicNotFoundException, IOException {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public void updateTopic(String topic, Map<String, String> properties) throws TopicNotFoundException, IOException {
+    // no-op
+  }
+
+  @Override
+  public void deleteTopic(String topic) throws TopicNotFoundException, IOException {
+    // no-op
+  }
+
+  @Override
+  public boolean datasetExists(String name) throws DatasetManagementException {
+    return false;
+  }
+
+  @Override
+  public String getDatasetType(String name) throws DatasetManagementException {
+    throw new InstanceNotFoundException(name);
+  }
+
+  @Override
+  public DatasetProperties getDatasetProperties(String name) throws DatasetManagementException {
+    throw new InstanceNotFoundException(name);
+  }
+
+  @Override
+  public void createDataset(String name, String type, DatasetProperties datasetProperties)
+    throws DatasetManagementException {
+    // no-op
+  }
+
+  @Override
+  public void updateDataset(String name, DatasetProperties datasetProperties) throws DatasetManagementException {
+    // no-op
+  }
+
+  @Override
+  public void dropDataset(String name) throws DatasetManagementException {
+    // no-op
+  }
+
+  @Override
+  public void truncateDataset(String name) throws DatasetManagementException {
+    // no-op
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name) throws DatasetInstantiationException {
+    throw new DatasetInstantiationException("Cannot get dataset through no-op AuthorizationContext");
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String dataset) throws DatasetInstantiationException {
+    throw new DatasetInstantiationException("Cannot get dataset through no-op AuthorizationContext");
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String name, Map<String, String> map)
+    throws DatasetInstantiationException {
+    throw new DatasetInstantiationException("Cannot get dataset through no-op AuthorizationContext");
+  }
+
+  @Override
+  public <T extends Dataset> T getDataset(String namespace, String dataset,
+                                          Map<String, String> properties) throws DatasetInstantiationException {
+    throw new DatasetInstantiationException("Cannot get dataset through no-op AuthorizationContext");
+  }
+
+  @Override
+  public void releaseDataset(Dataset dataset) {
+    // no-op
+  }
+
+  @Override
+  public void discardDataset(Dataset dataset) {
+    // no-op
+  }
+
+  @Override
+  public void execute(TxRunnable txRunnable) throws TransactionFailureException {
+    // no-op
+  }
+
+  @Override
+  public void execute(int timeout, TxRunnable txRunnable) throws TransactionFailureException {
+    // no-op
+  }
+}

--- a/cdap-ranger/cdap-ranger-binding/src/test/java/co/cask/cdap/security/authorization/ranger/binding/RangerAdminClientImpl.java
+++ b/cdap-ranger/cdap-ranger-binding/src/test/java/co/cask/cdap/security/authorization/ranger/binding/RangerAdminClientImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.security.authorization.ranger.binding;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.ranger.admin.client.RangerAdminClient;
+import org.apache.ranger.plugin.util.GrantRevokeRequest;
+import org.apache.ranger.plugin.util.ServicePolicies;
+import org.apache.ranger.plugin.util.ServiceTags;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * A test implementation of the RangerAdminClient interface that just reads policies in from a file and returns them.
+ * Note: This code is taken from Apache Ranger
+ * https://github.com/apache/ranger/blob/master/hdfs-agent/src/test/java/org/apache/ranger
+ * /services/hdfs/RangerAdminClientImpl.java
+ */
+public class RangerAdminClientImpl implements RangerAdminClient {
+  private static final Logger LOG = LoggerFactory.getLogger(RangerAdminClientImpl.class);
+  private static final String CDAP_POLICIES_JSON = "cdap-policies.json";
+  private Gson gson;
+
+  public void init(String serviceName, String appId, String configPropertyPrefix) {
+    Gson gson = null;
+    try {
+      gson = new GsonBuilder().setDateFormat("yyyyMMdd-HH:mm:ss.SSS-Z").setPrettyPrinting().create();
+    } catch (Throwable t) {
+      LOG.error("RangerAdminClientImpl: failed to create GsonBuilder object", t);
+    }
+    this.gson = gson;
+  }
+
+  public ServicePolicies getServicePoliciesIfUpdated(long lastKnownVersion,
+                                                     long lastActivationTimeInMillis) throws Exception {
+    String basedir = System.getProperty("basedir");
+    if (basedir == null) {
+      basedir = new File(".").getCanonicalPath();
+    }
+    Path cachePath = FileSystems.getDefault().getPath(basedir, "/src/test/resources/" + CDAP_POLICIES_JSON);
+    byte[] cacheBytes = Files.readAllBytes(cachePath);
+    return gson.fromJson(new String(cacheBytes), ServicePolicies.class);
+  }
+
+  public void grantAccess(GrantRevokeRequest request) throws Exception {
+    // no-op
+  }
+
+  public void revokeAccess(GrantRevokeRequest request) throws Exception {
+    // no-op
+  }
+
+  public ServiceTags getServiceTagsIfUpdated(long lastKnownVersion, long lastActivationTimeInMillis) throws Exception {
+    // cdap does not support tag based authorization at this point
+    return new ServiceTags();
+  }
+
+  public List<String> getTagTypes(String tagTypePattern) throws Exception {
+    return null;
+  }
+}

--- a/cdap-ranger/cdap-ranger-binding/src/test/java/co/cask/cdap/security/authorization/ranger/binding/RangerAuthorizerTest.java
+++ b/cdap-ranger/cdap-ranger-binding/src/test/java/co/cask/cdap/security/authorization/ranger/binding/RangerAuthorizerTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright © 2017 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package co.cask.cdap.security.authorization.ranger.binding;
+
+import co.cask.cdap.proto.ProgramType;
+import co.cask.cdap.proto.id.EntityId;
+import co.cask.cdap.proto.id.InstanceId;
+import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.proto.security.Action;
+import co.cask.cdap.proto.security.Principal;
+import co.cask.cdap.security.spi.authorization.UnauthorizedException;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Test {@link RangerAuthorizer} through a policies stored in a file under resources/cdap-policies.json
+ */
+public class RangerAuthorizerTest {
+
+  private static final NamespaceId NAMESPACE_DEFAULT = new NamespaceId("default");
+  private static final Principal ALI = new Principal("ali", Principal.PrincipalType.USER);
+  private static final Principal SAGAR = new Principal("sagar", Principal.PrincipalType.USER);
+  private static final Principal SHANKAR = new Principal("shankar", Principal.PrincipalType.USER);
+  private static final Principal MATT = new Principal("matt", Principal.PrincipalType.USER);
+  private static final Principal POORNA = new Principal("poorna", Principal.PrincipalType.USER);
+  private static final Principal RSINHA = new Principal("rsinha", Principal.PrincipalType.USER);
+  private static final Principal DEREK = new Principal("derek", Principal.PrincipalType.USER);
+  private static final Principal ALBERT = new Principal("albert", Principal.PrincipalType.USER);
+  private static final Principal SREE = new Principal("sree", Principal.PrincipalType.USER);
+  private static final Principal YAOJIE = new Principal("yaojie", Principal.PrincipalType.USER);
+
+  private static RangerAuthorizer authorizer;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    authorizer = new RangerAuthorizer();
+    authorizer.initialize(new InMemoryAuthorizationContext());
+  }
+
+  @Test
+  public void testCompletePrivileges() throws Exception {
+    // Test Privileges for ali who has ADMIN on stream:default:teststream
+    authorizer.enforce(NAMESPACE_DEFAULT.stream("teststream"), ALI, Action.ADMIN);
+    Assert.assertEquals(ImmutableSet.of(NAMESPACE_DEFAULT, NAMESPACE_DEFAULT.stream("teststream")),
+                        authorizer.isVisible(ImmutableSet.<EntityId>of(NAMESPACE_DEFAULT,
+                                                                       NAMESPACE_DEFAULT.stream("teststream")), ALI));
+    testEnforceFail(NAMESPACE_DEFAULT.stream("anotherstream"), ALI, Action.ADMIN);
+    testVisibleFail(ImmutableSet.<EntityId>of(new NamespaceId("anothernamespace")), ALI);
+    testEnforceFail(NAMESPACE_DEFAULT.stream("teststream"), ALI, Action.READ);
+    testEnforceFail(NAMESPACE_DEFAULT, ALI, Action.ADMIN);
+
+    // Test privileges for rsinha who has ADMIN on namespace:default
+    authorizer.enforce(NAMESPACE_DEFAULT, RSINHA, Action.ADMIN);
+    testEnforceFail(new NamespaceId("anothernamespace"), RSINHA, Action.ADMIN);
+    Assert.assertEquals(ImmutableSet.of(NAMESPACE_DEFAULT),
+                        authorizer.isVisible(ImmutableSet.<EntityId>of(NAMESPACE_DEFAULT,
+                                                                       NAMESPACE_DEFAULT.stream("teststream")),
+                                             RSINHA));
+    testVisibleFail(ImmutableSet.<EntityId>of(new NamespaceId("anothernamespace")), RSINHA);
+    testEnforceFail(new InstanceId("cdap"), RSINHA, Action.ADMIN);
+    testEnforceFail(NAMESPACE_DEFAULT, RSINHA, Action.WRITE);
+    testEnforceFail(NAMESPACE_DEFAULT.stream("teststream"), RSINHA, Action.ADMIN);
+
+    // Test Privileges for poorna who has READ on instance:cdap
+    authorizer.enforce(new InstanceId("cdap"), POORNA, Action.READ);
+    testVisibleFail(ImmutableSet.<EntityId>of(NAMESPACE_DEFAULT), POORNA);
+    testEnforceFail(NAMESPACE_DEFAULT, POORNA, Action.READ);
+    testEnforceFail(new InstanceId("cdap"), POORNA, Action.ADMIN);
+
+    // Test privileges for matt who has READ and EXECUTE on program:anotherns.testapp.WORKFLOW.testworkflow
+    authorizer.enforce(new NamespaceId("anotherns").app("testapp").program(ProgramType.WORKFLOW, "testworkflow"), MATT,
+                       ImmutableSet.of(Action.READ, Action.EXECUTE));
+    // test to make sure versions don't affect
+    authorizer.enforce(
+      new NamespaceId("anotherns").app("testapp", "1.0-SNAPSHOT").program(ProgramType.WORKFLOW, "testworkflow"),
+      MATT, ImmutableSet.of(Action.READ, Action.EXECUTE)
+    );
+    testEnforceFail(new NamespaceId("anotherns").app("testapp").program(ProgramType.WORKFLOW, "anotherworkflow"), MATT,
+                    Action.READ);
+    testEnforceFail(new NamespaceId("anotherns").app("testapp").program(ProgramType.MAPREDUCE, "testworkflow"), MATT,
+                    Action.READ);
+    testEnforceFail(new NamespaceId("anotherns").app("testapp"), MATT, Action.READ);
+    Assert.assertEquals(ImmutableSet.of(new NamespaceId("anotherns").app("testapp"),
+                                        new NamespaceId("anotherns")),
+                        authorizer.isVisible(ImmutableSet.<EntityId>of(new NamespaceId("anotherns").app("testapp"),
+                                                                       new NamespaceId("anotherns")), MATT));
+    testVisibleFail(ImmutableSet.<EntityId>of(NAMESPACE_DEFAULT), MATT);
+    testEnforceFail(NAMESPACE_DEFAULT.app("testapp").program(ProgramType.WORKFLOW, "testworkflow"), MATT,
+                    Action.EXECUTE);
+
+    // Test dataset type and module specifically as they can contain . in their names.
+    authorizer.enforce(NAMESPACE_DEFAULT.datasetType("co.cask.table_1_mod"), DEREK, Action.READ);
+    testEnforceFail(new NamespaceId("anotherns").datasetType("co.cask.table_1_mod"), DEREK, Action.READ);
+    testEnforceFail(NAMESPACE_DEFAULT.datasetType("co.cask"), DEREK, Action.READ);
+
+    authorizer.enforce(NAMESPACE_DEFAULT.datasetModule("co.cask.table_1_mod"), ALBERT, Action.READ);
+    authorizer.enforce(NAMESPACE_DEFAULT.datasetModule("co.cask.table_2_mod"), ALBERT, Action.READ);
+    testEnforceFail(new NamespaceId("anotherns").datasetType("co.cask.table_1_mod"), ALBERT, Action.READ);
+    testEnforceFail(NAMESPACE_DEFAULT.datasetType("co.cask"), ALBERT, Action.READ);
+
+    // Test artifacts: we don't enforce on version for artifacts
+    authorizer.enforce(NAMESPACE_DEFAULT.artifact("DataPipeline", "1.0-SNAPSHOT"), SREE, Action.READ);
+    authorizer.enforce(NAMESPACE_DEFAULT.artifact("DataPipeline", "2.0-SNAPSHOT"), SREE, Action.READ);
+    testEnforceFail(new NamespaceId("anotherns").artifact("DataPipeline", "1.0-SNAPSHOT"), SREE, Action.READ);
+    // cdap entities are case sensitive
+    testEnforceFail(NAMESPACE_DEFAULT.artifact("datapipeline", "1.0-SNAPSHOT"), SREE, Action.READ);
+  }
+
+  @Test
+  public void testWildcardPrivileges() throws Exception {
+    // Test privileges for sagar who has ADMIN on stream:default.*
+    authorizer.enforce(NAMESPACE_DEFAULT.stream("teststream"), SAGAR, Action.ADMIN);
+    authorizer.enforce(NAMESPACE_DEFAULT.stream("anotherstream"), SAGAR, Action.ADMIN);
+    testEnforceFail(NAMESPACE_DEFAULT.stream("teststream"), SAGAR, Action.READ);
+    testEnforceFail(NAMESPACE_DEFAULT, SAGAR, Action.ADMIN);
+    Assert.assertEquals(ImmutableSet.of(NAMESPACE_DEFAULT, NAMESPACE_DEFAULT.stream("teststream")),
+                        authorizer.isVisible(ImmutableSet.<EntityId>of(NAMESPACE_DEFAULT,
+                                                                       NAMESPACE_DEFAULT.stream("teststream")), SAGAR));
+    testVisibleFail(ImmutableSet.<EntityId>of(new NamespaceId("anothernamespace")), SAGAR);
+    testEnforceFail(new NamespaceId("anothernamespace").stream("teststream"), SAGAR, Action.ADMIN);
+
+    // Test privileges for shankar who has ADMIN on program:default.testapp.workflow.*
+    authorizer.enforce(NAMESPACE_DEFAULT.app("testapp").program(ProgramType.WORKFLOW, "prog1"), SHANKAR, Action.ADMIN);
+    authorizer.enforce(NAMESPACE_DEFAULT.app("testapp").program(ProgramType.WORKFLOW, "prog2"), SHANKAR, Action.ADMIN);
+    testEnforceFail(NAMESPACE_DEFAULT.app("testapp").program(ProgramType.MAPREDUCE, "prog1"), SHANKAR, Action.ADMIN);
+    testEnforceFail(NAMESPACE_DEFAULT.app("testapp").program(ProgramType.WORKFLOW, "prog1"), SHANKAR, Action.READ);
+    testEnforceFail(NAMESPACE_DEFAULT.app("testapp"), SHANKAR, Action.ADMIN);
+    Assert.assertEquals(ImmutableSet.of(NAMESPACE_DEFAULT.app("testapp"), NAMESPACE_DEFAULT),
+                        authorizer.isVisible(ImmutableSet.<EntityId>of(NAMESPACE_DEFAULT.app("testapp"),
+                                                                       NAMESPACE_DEFAULT), SHANKAR));
+    testVisibleFail(ImmutableSet.<EntityId>of(new NamespaceId("anothernamespace")), SHANKAR);
+    testVisibleFail(ImmutableSet.<EntityId>of(NAMESPACE_DEFAULT.app("testapp").program(ProgramType.MAPREDUCE, "prog1")),
+                    SHANKAR);
+
+    // Test privileges for Yaojie who has EXECUTE on program:default.testapp.*
+    authorizer.enforce(NAMESPACE_DEFAULT.app("testapp").program(ProgramType.WORKFLOW, "prog1"), YAOJIE,
+                       Action.EXECUTE);
+    authorizer.enforce(NAMESPACE_DEFAULT.app("testapp").program(ProgramType.WORKFLOW, "prog2"), YAOJIE,
+                       Action.EXECUTE);
+    authorizer.enforce(NAMESPACE_DEFAULT.app("testapp").program(ProgramType.MAPREDUCE, "prog1"), YAOJIE,
+                       Action.EXECUTE);
+    Assert.assertEquals(ImmutableSet.of(NAMESPACE_DEFAULT, NAMESPACE_DEFAULT.app("testapp")),
+                        authorizer.isVisible(ImmutableSet.of(NAMESPACE_DEFAULT, NAMESPACE_DEFAULT.app("testapp")),
+                                             YAOJIE));
+    testEnforceFail(new NamespaceId("test").app("testapp").program(ProgramType.MAPREDUCE, "prog1"), YAOJIE,
+                       Action.EXECUTE);
+  }
+
+  private void testEnforceFail(EntityId entityId, Principal principal, Action action) throws Exception {
+    try {
+      authorizer.enforce(entityId, principal, action);
+      Assert.fail(String.format("Principal %s, should be unauthorized for %s on entity %s", entityId, principal,
+                                action));
+    } catch (UnauthorizedException e) {
+      // expected
+    }
+  }
+
+  private void testVisibleFail(Set<? extends EntityId> entities, Principal principal) throws Exception {
+    Assert.assertEquals(Collections.EMPTY_SET, authorizer.isVisible(entities, principal));
+  }
+}

--- a/cdap-ranger/cdap-ranger-binding/src/test/resources/cdap-policies.json
+++ b/cdap-ranger/cdap-ranger-binding/src/test/resources/cdap-policies.json
@@ -1,0 +1,881 @@
+{
+  "serviceName": "cdap",
+  "serviceId": 11,
+  "policyVersion": 5,
+  "policyUpdateTime": "20170220-14:17:37.000-+0000",
+  "policies": [
+    {
+      "service": "cdapdev",
+      "name": "shankar policy",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "application": {
+          "values": [
+            "testapp"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "program": {
+          "values": [
+            "workflow.?*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "admin",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "shankar"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 355,
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "cdapdev",
+      "name": "rsinha",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "artifact": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": true,
+          "isRecursive": false
+        },
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "admin",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "rsinha"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 356,
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "cdapdev",
+      "name": "sagar",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "stream": {
+          "values": [
+            "?*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "admin",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "sagar"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 357,
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "cdapdev",
+      "name": "ali",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "stream": {
+          "values": [
+            "teststream"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "admin",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "ali"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 358,
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "cdapdev",
+      "name": "poorna",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "application": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": true,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": true,
+          "isRecursive": false
+        },
+        "program": {
+          "values": [
+            "*"
+          ],
+          "isExcludes": true,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "read",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "poorna"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 359,
+      "isEnabled": true,
+      "version": 1
+    },
+    {
+      "service": "cdapdev",
+      "name": "matt",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "application": {
+          "values": [
+            "testapp"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "anotherns"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "program": {
+          "values": [
+            "workflow.testworkflow"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "read",
+              "isAllowed": true
+            },
+            {
+              "type": "execute",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "matt"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 360,
+      "isEnabled": true,
+      "version": 2
+    },
+    {
+      "service": "cdapdev",
+      "name": "derek",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "dataset_type": {
+          "values": [
+            "co.cask.table_1_mod"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "read",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "derek"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 361,
+      "isEnabled": true,
+      "version": 2
+    },
+    {
+      "service": "cdapdev",
+      "name": "albert",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "dataset_module": {
+          "values": [
+            "co.cask.*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "read",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "albert"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 362,
+      "isEnabled": true,
+      "version": 2
+    },
+    {
+      "service": "cdapdev",
+      "name": "sree",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "artifact": {
+          "values": [
+            "DataPipeline"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "read",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "sree"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 363,
+      "isEnabled": true,
+      "version": 2
+    },
+    {
+      "service": "cdapdev",
+      "name": "yaojie",
+      "policyType": 0,
+      "description": "",
+      "isAuditEnabled": true,
+      "resources": {
+        "instance": {
+          "values": [
+            "cdap"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "application": {
+          "values": [
+            "testapp"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "namespace": {
+          "values": [
+            "default"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        },
+        "program": {
+          "values": [
+            "?*"
+          ],
+          "isExcludes": false,
+          "isRecursive": false
+        }
+      },
+      "policyItems": [
+        {
+          "accesses": [
+            {
+              "type": "execute",
+              "isAllowed": true
+            }
+          ],
+          "users": [
+            "yaojie"
+          ],
+          "groups": [],
+          "conditions": [],
+          "delegateAdmin": false
+        }
+      ],
+      "denyPolicyItems": [],
+      "allowExceptions": [],
+      "denyExceptions": [],
+      "dataMaskPolicyItems": [],
+      "rowFilterPolicyItems": [],
+      "id": 364,
+      "isEnabled": true,
+      "version": 1
+    }
+  ],
+  "serviceDef": {
+    "id": 11,
+    "name": "cdap",
+    "implClass": "co.cask.cdap.security.authorization.ranger.lookup.RangerLookupService",
+    "label": "CDAP",
+    "description": "CDAP",
+    "resources": [
+      {
+        "itemId": 1,
+        "name": "instance",
+        "type": "string",
+        "level": 10,
+        "parent": "",
+        "mandatory": true,
+        "lookupSupported": false,
+        "recursiveSupported": false,
+        "excludesSupported": false,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "CDAP Instance",
+        "description": "CDAP Instance"
+      },
+      {
+        "itemId": 2,
+        "name": "namespace",
+        "type": "string",
+        "level": 20,
+        "parent": "instance",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Namespace",
+        "description": "CDAP Namespace"
+      },
+      {
+        "itemId": 30,
+        "name": "application",
+        "type": "string",
+        "level": 30,
+        "parent": "namespace",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Application",
+        "description": "CDAP Application"
+      },
+      {
+        "itemId": 40,
+        "name": "artifact",
+        "type": "string",
+        "level": 30,
+        "parent": "namespace",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Artifact",
+        "description": "CDAP Artifact"
+      },
+      {
+        "itemId": 50,
+        "name": "dataset",
+        "type": "string",
+        "level": 30,
+        "parent": "namespace",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Dataset",
+        "description": "CDAP Dataset"
+      },
+      {
+        "itemId": 60,
+        "name": "dataset_module",
+        "type": "string",
+        "level": 30,
+        "parent": "namespace",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Dataset Module",
+        "description": "CDAP Dataset Module"
+      },
+      {
+        "itemId": 70,
+        "name": "dataset_type",
+        "type": "string",
+        "level": 30,
+        "parent": "namespace",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Dataset Type",
+        "description": "CDAP Dataset Type"
+      },
+      {
+        "itemId": 80,
+        "name": "secure_key",
+        "type": "string",
+        "level": 30,
+        "parent": "namespace",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Secure Key",
+        "description": "CDAP Secure Key"
+      },
+      {
+        "itemId": 90,
+        "name": "stream",
+        "type": "string",
+        "level": 30,
+        "parent": "namespace",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Stream",
+        "description": "CDAP Stream"
+      },
+      {
+        "itemId": 100,
+        "name": "principal",
+        "type": "string",
+        "level": 20,
+        "parent": "instance",
+        "mandatory": true,
+        "lookupSupported": false,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Principal",
+        "description": "Kerberos Principal"
+      },
+      {
+        "itemId": 110,
+        "name": "program",
+        "type": "string",
+        "level": 40,
+        "parent": "application",
+        "mandatory": true,
+        "lookupSupported": true,
+        "recursiveSupported": false,
+        "excludesSupported": true,
+        "matcher": "org.apache.ranger.plugin.resourcematcher.RangerDefaultResourceMatcher",
+        "matcherOptions": {
+          "wildCard": true,
+          "ignoreCase": false
+        },
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Program",
+        "description": "CDAP Program"
+      }
+    ],
+    "accessTypes": [
+      {
+        "itemId": 1,
+        "name": "read",
+        "label": "Read"
+      },
+      {
+        "itemId": 2,
+        "name": "write",
+        "label": "Write"
+      },
+      {
+        "itemId": 3,
+        "name": "execute",
+        "label": "Execute"
+      },
+      {
+        "itemId": 4,
+        "name": "admin",
+        "label": "Admin"
+      }
+    ],
+    "configs": [
+      {
+        "itemId": 1,
+        "name": "cdap.username",
+        "type": "string",
+        "subType": "",
+        "mandatory": true,
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Username"
+      },
+      {
+        "itemId": 2,
+        "name": "cdap.password",
+        "type": "password",
+        "subType": "",
+        "mandatory": true,
+        "validationRegEx": "",
+        "validationMessage": "",
+        "uiHint": "",
+        "label": "Password"
+      },
+      {
+        "itemId": 3,
+        "name": "cdap.instance.url",
+        "type": "string",
+        "subType": "",
+        "mandatory": true,
+        "label": "Instance URL",
+        "defaultValue": "",
+        "validationRegEx": "",
+        "validationMessage": ""
+      }
+    ],
+    "enums": [],
+    "contextEnrichers": [],
+    "policyConditions": []
+  },
+  "auditMode": "audit-default"
+}

--- a/cdap-ranger/cdap-ranger-binding/src/test/resources/ranger-cdap-security.xml
+++ b/cdap-ranger/cdap-ranger-binding/src/test/resources/ranger-cdap-security.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<!--
+Copyright © 2017 Cask Data, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+-->
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>ranger.plugin.kafka.policy.rest.url</name>
+    <value>http://localhost:6080</value>
+    <description>
+      URL to Ranger Admin
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.cdap.service.name</name>
+    <value>cdapdev</value>
+    <description>
+      Name of the Ranger service containing policies for this cdap instance
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.cdap.policy.source.impl</name>
+    <value>co.cask.cdap.security.authorization.ranger.binding.RangerAdminClientImpl</value>
+    <description>
+      Policy source.
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.kafka.policy.pollIntervalMs</name>
+    <value>30000</value>
+    <description>
+      How often to poll for changes in policies?
+    </description>
+  </property>
+
+  <property>
+    <name>ranger.plugin.cdap.policy.cache.dir</name>
+    <value>${project.build.directory}</value>
+    <description>
+      Directory where Ranger policies are cached after successful retrieval from the source
+    </description>
+  </property>
+
+</configuration>

--- a/cdap-ranger/cdap-ranger-common/src/main/java/co/cask/cdap/security/authorization/ranger/commons/RangerCommon.java
+++ b/cdap-ranger/cdap-ranger-common/src/main/java/co/cask/cdap/security/authorization/ranger/commons/RangerCommon.java
@@ -34,7 +34,6 @@ public class RangerCommon {
   public static final String KEY_SECUREKEY = "securekey";
   public static final String KEY_PRINCIPAL = "principal";
 
-  // using # as we don't allow it in entity names
-  public static final String RESOURCE_SEPARATOR = "#";
+  public static final String RESOURCE_SEPARATOR = ".";
 
 }

--- a/cdap-ranger/cdap-ranger-lookup/src/main/java/co/cask/cdap/security/authorization/ranger/lookup/client/CDAPRangerLookupClient.java
+++ b/cdap-ranger/cdap-ranger-lookup/src/main/java/co/cask/cdap/security/authorization/ranger/lookup/client/CDAPRangerLookupClient.java
@@ -241,7 +241,13 @@ public class CDAPRangerLookupClient {
               Preconditions.checkNotNull(list, "Failed to list resources of type %s", resource.trim());
               if (!userInput.isEmpty()) {
                 for (String value : list) {
-                  if (value.startsWith(userInput)) {
+                  // programs are taken as programtype.programname but for matching purpose we only want to match on
+                  // the program name.
+                  String matchPart = value;
+                  if (resource.trim().toLowerCase().equalsIgnoreCase(RangerCommon.KEY_PROGRAM)) {
+                    matchPart = value.substring(value.indexOf(".") + 1, value.length());
+                  }
+                  if (matchPart.startsWith(userInput)) {
                     retList.add(value);
                   }
                 }
@@ -467,7 +473,8 @@ public class CDAPRangerLookupClient {
         String name = programRecord.getName();
         if (programList == null || !programs.contains(name)) {
           // we display program type as suffix because if its in prefix the lookup user will need to enter type first
-          programs.add(Joiner.on(":").join(name, programRecord.getType().getPrettyName()));
+          programs.add(Joiner.on(RangerCommon.RESOURCE_SEPARATOR).
+            join(programRecord.getType().getPrettyName().toLowerCase(), name));
         }
       }
     } else {

--- a/cdap-ranger/cdap-ranger-lookup/src/test/java/co/cask/cdap/security/authorization/ranger/lookup/client/CDAPRangerLookupClientTest.java
+++ b/cdap-ranger/cdap-ranger-lookup/src/test/java/co/cask/cdap/security/authorization/ranger/lookup/client/CDAPRangerLookupClientTest.java
@@ -26,6 +26,7 @@ import co.cask.cdap.proto.ProgramType;
 import co.cask.cdap.proto.StreamDetail;
 import co.cask.cdap.proto.id.ApplicationId;
 import co.cask.cdap.proto.id.NamespaceId;
+import co.cask.cdap.security.authorization.ranger.commons.RangerCommon;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -117,8 +118,9 @@ public class CDAPRangerLookupClientTest {
                                                                              ImmutableList.of("dummyApp")));
     List<String> resources = client.getResources(resourceLookupContext);
     Assert.assertEquals(2, resources.size());
-    Assert.assertEquals(ImmutableList.of(Joiner.on(":").join("prog1", ProgramType.FLOW.getPrettyName()),
-                                         Joiner.on(":").join("prog2", ProgramType.MAPREDUCE.getPrettyName())),
+    Assert.assertEquals(ImmutableList.of(
+      Joiner.on(RangerCommon.RESOURCE_SEPARATOR).join(ProgramType.FLOW.getPrettyName().toLowerCase(), "prog1"),
+      Joiner.on(RangerCommon.RESOURCE_SEPARATOR).join(ProgramType.MAPREDUCE.getPrettyName().toLowerCase(), "prog2")),
                         resources);
   }
 }

--- a/cdap-ranger/pom.xml
+++ b/cdap-ranger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>co.cask.cdap</groupId>
     <artifactId>cdap-security-extensions</artifactId>
-    <version>0.6.0-SNAPSHOT</version>
+    <version>0.6.0</version>
   </parent>
 
   <artifactId>cdap-ranger</artifactId>
@@ -71,7 +71,7 @@
 
   <properties>
     <hadoop.version>2.3.0</hadoop.version>
-    <ranger.version>0.7.0</ranger.version>
+    <ranger.version>0.7.1</ranger.version>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
   <version>0.6.0</version>
 
   <modules>
+    <module>cdap-ranger</module>
     <module>cdap-sentry</module>
     <module>cdap-security-extensions-dist</module>
   </modules>


### PR DESCRIPTION
Also changed the resource separator to . from # as its more consistent with our entity representation.