### PR TITLE
Fix indentation that fixes sphinx voodo magic

### DIFF
--- a/cdap-ranger/README.rst
+++ b/cdap-ranger/README.rst
@@ -247,103 +247,119 @@ such a use case at the hand of an example. Suppose that:
 In a cluster with Ranger authorization, what are the Ranger policies required to enable this scenario?
 Let’s go through the steps:
 
-1. To begin with, we need two Unix users with Kerberos principals and keytab files that will
-   allow impersonating them:
+1. To begin with, we need two Unix users with Kerberos principals and keytab files that will 
+allow impersonating them:
 
 .. image:: _images/ranger-case-study-keytabs.png
+  :align: center
 
-   Note that these key tabs must be readable for the cdap system account.
+Note that these key tabs must be readable for the cdap system account.
 
 2. To create the ``clicks`` namespace, Alice logs into the CDAP UI. Initially, she cannot access any
    namespaces:
 
 .. image:: _images/ranger-case-study-no-access.png
+  :align: center
 
-   To allow her the creation of these two namespaces with impersonation, we need to give her privileges
-   on the principals and the namespaces in Ranger:
+To allow her the creation of these two namespaces with impersonation, we need to give her privileges
+on the principals and the namespaces in Ranger:
 
 .. image:: _images/ranger-case-study-policy-principals.png
+  :align: center
 
-   Here, we give Alice ``ADMIN`` right on any principal starting with ``svc``.
-   If you need more control, you can also give an explicit list of principals, as we
-   do here for the namespaces:
+Here, we give Alice ``ADMIN`` right on any principal starting with ``svc``.
+If you need more control, you can also give an explicit list of principals, as we
+do here for the namespaces:
 
 .. image:: _images/ranger-case-study-policy-namespace.png
+  :align: center
 
-   Due to a limitation in Ranger, it is not possible to assign policies for “intermediate”
-   entities in the entity hierarchy. Because of that, we need to use the work-around above:
-   Specify ``*`` for both the application and the program, and select “exclude” for both of them.
-   This is the way to define a policy for a namespace.
+Due to a limitation in Ranger, it is not possible to assign policies for “intermediate”
+entities in the entity hierarchy. Because of that, we need to use the work-around above:
+Specify ``*`` for both the application and the program, and select “exclude” for both of them.
+This is the way to define a policy for a namespace.
 
 3. Now Alice can create the two namespaces, for example, ``clicks``:
 
 .. image:: _images/ranger-case-study-create-ns.png
+  :align: center
 
 .. image:: _images/ranger-case-study-create-ns2.png
+  :align: center
 
 .. image:: _images/ranger-case-study-create-ns3.png
+  :align: center
 
 .. image:: _images/ranger-case-study-create-ns4.png
+  :align: center
 
 4. Now let’s create a pipeline. Without additional policies in Ranger, this will fail:
 
 .. image:: _images/ranger-case-study-deploy-fail1.png
+  :align: center
 
-   We are required to give Alice ``ADMIN`` privileges on the pipeline applications she deploys.
+We are required to give Alice ``ADMIN`` privileges on the pipeline applications she deploys.
 
-   Note that in CDAP, an application is a group of programs that logically belong together.
-   A pipeline is an application with the same name as the pipeline. It contains the Data Pipeline
-   Workflow and the MapReduce or Spark programs that execute the pipeline. For deploying the pipeline,
-   we need ``ADMIN`` rights on this application. Here, we give these rights for all applications
-   in the namespace, that is, Alice can deploy any pipeline:
+Note that in CDAP, an application is a group of programs that logically belong together.
+A pipeline is an application with the same name as the pipeline. It contains the Data Pipeline
+Workflow and the MapReduce or Spark programs that execute the pipeline. For deploying the pipeline,
+we need ``ADMIN`` rights on this application. Here, we give these rights for all applications
+in the namespace, that is, Alice can deploy any pipeline:
 
 .. image:: _images/ranger-case-study-policy-apps.png
+  :align: center
 
-   Similar to namespace policies, we need to work around a ranger limitation to assign
-   policies to an application. Enter ``?*`` for "application" and ``*`` for "program" and
-   select “exclude” for the program.
+Similar to namespace policies, we need to work around a ranger limitation to assign
+policies to an application. Enter ``?*`` for "application" and ``*`` for "program" and
+select “exclude” for the program.
 
-   Now let’s try to deploy the pipeline again:
+Now let’s try to deploy the pipeline again:
 
 .. image:: _images/ranger-case-study-deploy-fail2.png
+  :align: center
 
-   This still fails because the pipeline is trying to create the datasets for its source and sink,
-   but we have not given any privileges on datasets yet. Because the pipeline is impersonated as
-   the service account ``svcclicks``, we must assign these privileges to that user. Strictly speaking,
-   only ``ADMIN`` is required to create the datasets, but later on, when we run the pipeline, it will
-   need read and write access, too. Therefore, we just assign all these privileges now:
+This still fails because the pipeline is trying to create the datasets for its source and sink,
+but we have not given any privileges on datasets yet. Because the pipeline is impersonated as
+the service account ``svcclicks``, we must assign these privileges to that user. Strictly speaking,
+only ``ADMIN`` is required to create the datasets, but later on, when we run the pipeline, it will
+need read and write access, too. Therefore, we just assign all these privileges now:
 
 .. image:: _images/ranger-case-study-policy-datasets.png
+  :align: center
 
-   With this, pipeline deployment succeeds.
+
+With this, pipeline deployment succeeds.
 
 5. Let’s run the pipeline to ingest some data. Starting the pipeline is equivalent to starting
-   the DataPipelineWorkflow program of the pipeline’s application. This fails with insufficient
-   privileges. However, the error message does not make this obvious:
+the DataPipelineWorkflow program of the pipeline’s application. This fails with insufficient
+privileges. However, the error message does not make this obvious:
 
 .. image:: _images/ranger-case-study-start-fail.png
+  :align: center
 
-   Because Alice has no privileges at all on the pipeline’s programs, it is also not allowed
-   to find out about their existence. Therefore, the platform APIs return a “Not Found” error
-   for this request. This can be confusing at first - however, it is common practice for
-   secure APIs to behave this way.
+Because Alice has no privileges at all on the pipeline’s programs, it is also not allowed
+to find out about their existence. Therefore, the platform APIs return a “Not Found” error
+for this request. This can be confusing at first - however, it is common practice for
+secure APIs to behave this way.
 
-   Let’s assign the missing privileges to Alice:
+Let’s assign the missing privileges to Alice:
 
 .. image:: _images/ranger-case-study-policy-programs.png
+  :align: center
 
-   Note that only the ``EXECUTE`` privilege is required to start or stop a pipeline run,
-   and the ``ADMIN`` privilege is needed to schedule the pipeline.
+Note that only the ``EXECUTE`` privilege is required to start or stop a pipeline run,
+and the ``ADMIN`` privilege is needed to schedule the pipeline.
 
-   Now Alice can run this pipeline:
+Now Alice can run this pipeline:
 
 .. image:: _images/ranger-case-study-start-success.png
+  :align: center
 
 6. We can repeat these steps to assign similar privileges to Bob, or to enable the
-   ``finance`` namespace. Also, we could assign privileges to groups rather than
-   individuals - that will make our policies easier to manage over time, especially
-   when new operators enter the team, or existing ones leave: that will simply
-   require adding or removing a user from the group.
+``finance`` namespace. Also, we could assign privileges to groups rather than
+individuals - that will make our policies easier to manage over time, especially
+when new operators enter the team, or existing ones leave: that will simply
+require adding or removing a user from the group.
 
 Conclusion
 ----------


### PR DESCRIPTION
Ran the build just for previously failing rst and it now passes without warnings

```
[sree@Sreevatsans-MBP qs]$ sphinx-build -b html source build
Running Sphinx v1.6.5
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 2 source files that are out of date
updating environment: 2 added, 0 changed, 0 removed
reading sources... [100%] index                                                                                                                                      
looking for now-outdated files... none found
pickling environment... done
checking consistency... /private/tmp/qs/source/README.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] index                                                                                                                                       
generating indices... genindex
writing additional pages... search
copying images... [100%] _images/ranger_install1.png                                                                                                                 
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 1 warning.
```