### PR TITLE
Fix the broken build

### DIFF
--- a/cdap-ranger/cdap-ranger-binding/pom.xml
+++ b/cdap-ranger/cdap-ranger-binding/pom.xml
@@ -89,6 +89,12 @@
   </dependencies>
 
   <build>
+    <testResources>
+      <testResource>
+        <directory>${project.basedir}/src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
     <plugins>
       <plugin>
         <groupId>org.apache.felix</groupId>

--- a/cdap-ranger/cdap-ranger-lookup/pom.xml
+++ b/cdap-ranger/cdap-ranger-lookup/pom.xml
@@ -42,10 +42,6 @@
     </dependency>
     <dependency>
       <groupId>io.cdap.cdap</groupId>
-      <artifactId>cdap-cli</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.cdap.cdap</groupId>
       <artifactId>cdap-ranger-common</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/cdap-ranger/cdap-ranger-lookup/src/main/java/io/cdap/cdap/security/authorization/ranger/lookup/client/CDAPRangerLookupClient.java
+++ b/cdap-ranger/cdap-ranger-lookup/src/main/java/io/cdap/cdap/security/authorization/ranger/lookup/client/CDAPRangerLookupClient.java
@@ -22,7 +22,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import io.cdap.cdap.api.artifact.ArtifactSummary;
 import io.cdap.cdap.api.security.store.SecureStoreMetadata;
-import io.cdap.cdap.cli.util.InstanceURIParser;
 import io.cdap.cdap.client.ApplicationClient;
 import io.cdap.cdap.client.ArtifactClient;
 import io.cdap.cdap.client.DatasetClient;
@@ -462,8 +461,21 @@ public class CDAPRangerLookupClient {
    */
   private ClientConfig getClientConfig() {
     ClientConfig.Builder builder = new ClientConfig.Builder();
-    builder.setConnectionConfig(InstanceURIParser.DEFAULT.parse(
-      URI.create(instanceURL).toString()));
+    URI uri = URI.create(instanceURL);
+    String host = uri.getHost();
+    int port = uri.getPort();
+    String scheme = uri.getScheme();
+
+    if (scheme == null) {
+      scheme = "http";
+    }
+    if (port == -1) {
+      port = scheme.equals("https") ? 443 : 80;
+    }
+
+    ConnectionConfig connectionConfig = new ConnectionConfig(host, port, scheme.equals("https"));
+
+    builder.setConnectionConfig(connectionConfig);
     builder.setAccessToken(fetchAccessToken());
     String verifySSL = System.getProperty("verifySSL");
     if (verifySSL != null) {

--- a/pom.xml
+++ b/pom.xml
@@ -130,11 +130,6 @@
       </dependency>
       <dependency>
         <groupId>io.cdap.cdap</groupId>
-        <artifactId>cdap-cli</artifactId>
-        <version>${cdap.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.cdap.cdap</groupId>
         <artifactId>cdap-common</artifactId>
         <version>${cdap.version}</version>
         <scope>provided</scope>


### PR DESCRIPTION
- Remove unnecessary dependencies on cdap-cli
-- CDAP cli is a fat-jar, causing shade plugin issue
- Fix the test resources filtering to avoid creating a strange directory outside of target directory after running test