### PR TITLE
[CDAP-18928] Add support for InstancePermission.TETHER and InstancePermission.HEALTH_CHECK

### DIFF
--- a/cdap-ldap-role/pom.xml
+++ b/cdap-ldap-role/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <security.authorizer.class>io.cdap.cdap.security.authorization.ldap.role.LDAPRoleAccessController</security.authorizer.class>
-    <cdap.version>6.5.0</cdap.version>
+    <cdap.version>6.7.0-SNAPSHOT</cdap.version>
     <jackson.version>2.8.8</jackson.version>
     <maven.build.timestamp.format>HH:mm:ss dd-MM-yyyy</maven.build.timestamp.format>
   </properties>

--- a/cdap-ldap-role/src/main/java/io/cdap/cdap/security/authorization/ldap/role/permission/RolePermission.java
+++ b/cdap-ldap-role/src/main/java/io/cdap/cdap/security/authorization/ldap/role/permission/RolePermission.java
@@ -108,4 +108,10 @@ public enum RolePermission {
   MANAGE_SYSTEM_PREFERENCES,
   @JsonProperty("View System Services")
   VIEW_SYSTEM_SERVICES,
+
+  // System Administration
+  @JsonProperty("Initiate And Accept Tether")
+  INITIATE_AND_ACCEPT_TETHER,
+  @JsonProperty("Perform Health Check")
+  PERFORM_HEALTH_CHECK,
 }

--- a/cdap-ldap-role/src/test/java/io/cdap/cdap/security/authorization/ldap/role/permission/RolePermissionConverterTests.java
+++ b/cdap-ldap-role/src/test/java/io/cdap/cdap/security/authorization/ldap/role/permission/RolePermissionConverterTests.java
@@ -17,6 +17,7 @@
 package io.cdap.cdap.security.authorization.ldap.role.permission;
 
 import io.cdap.cdap.proto.element.EntityType;
+import io.cdap.cdap.proto.id.NamespaceId;
 import io.cdap.cdap.proto.security.StandardPermission;
 import org.junit.Assert;
 import org.junit.Test;
@@ -70,5 +71,16 @@ public class RolePermissionConverterTests {
     Assert.assertEquals(EntityType.SECUREKEY, entityTypeWithPermission.getEntityType());
     Assert.assertEquals(StandardPermission.GET, entityTypeWithPermission.getPermission());
     Assert.assertFalse(entityTypeWithPermission.isSystemNamespace());
+  }
+
+  @Test
+  public void testAllRolesConvertToNonEmptyEntityTypeWithPermissionSet() {
+    for (RolePermission rolePermission : RolePermission.values()) {
+      String errorMessage = String.format("RolePermission conversion '%s' to EntityTypeWithPermission unexpectedly " +
+                                            "returned empty list", rolePermission);
+      List<RolePermission> singleRolePermission = Collections.singletonList(rolePermission);
+      List<String> namespaces = Arrays.asList(NamespaceId.DEFAULT.getNamespace(), NamespaceId.SYSTEM.getNamespace());
+      Assert.assertTrue(errorMessage, RolePermissionConverter.convert(singleRolePermission, namespaces).size() > 0);
+    }
   }
 }


### PR DESCRIPTION
These permissions were added in https://github.com/cdapio/cdap/pull/13769 (TETHER) and https://github.com/cdapio/cdap/pull/13967 (HEALTH_CHECK).

Permissions Descriptions:
 - TETHER permission is required for the given user to initiate a tether request to a remote instance. TETHER permission is also required for a remote instance initiating a request to the local instance.
 -  HEALTH_CHECK permission is required for acquiring JVM information from a particular service.