### PR TITLE
Upgrade cdap version due to security vulnerability

### DIFF
--- a/cdap-ldap-role/pom.xml
+++ b/cdap-ldap-role/pom.xml
@@ -21,7 +21,6 @@
 
   <properties>
     <security.authorizer.class>io.cdap.cdap.security.authorization.ldap.role.LDAPRoleAccessController</security.authorizer.class>
-    <cdap.version>6.7.0-SNAPSHOT</cdap.version>
     <jackson.version>2.8.8</jackson.version>
     <maven.build.timestamp.format>HH:mm:ss dd-MM-yyyy</maven.build.timestamp.format>
   </properties>

--- a/cdap-ranger/cdap-ranger-binding/pom.xml
+++ b/cdap-ranger/cdap-ranger-binding/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>cdap-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ranger</groupId>
       <artifactId>ranger-plugins-common</artifactId>
     </dependency>

--- a/cdap-ranger/cdap-ranger-lookup/pom.xml
+++ b/cdap-ranger/cdap-ranger-lookup/pom.xml
@@ -46,6 +46,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>

--- a/cdap-ranger/pom.xml
+++ b/cdap-ranger/pom.xml
@@ -100,6 +100,14 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -111,7 +119,20 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/main/java/io/cdap/cdap/security/authorization/sentry/binding/AuthBinding.java
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/src/main/java/io/cdap/cdap/security/authorization/sentry/binding/AuthBinding.java
@@ -292,7 +292,7 @@ class AuthBinding {
       if (!entityType.equals(EntityType.INSTANCE)) {
         entityParts.remove(EntityType.INSTANCE);
       }
-      privileges.add(new Privilege(new io.cdap.cdap.proto.security.Authorizable(entityType, entityParts),
+      privileges.add(new Privilege(new io.cdap.cdap.proto.security.Authorizable(entityType, entityParts, null),
                                    Action.valueOf(sentryPrivilege.getAction().toUpperCase())));
     }
     return Collections.unmodifiableSet(privileges);

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.2.0</cdap.version>
-    <slf4j.version>1.7.5</slf4j.version>
+    <cdap.version>6.9.0-SNAPSHOT</cdap.version>
+    <slf4j.version>1.7.15</slf4j.version>
     <junit.version>4.11</junit.version>
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
   </properties>


### PR DESCRIPTION
- Update cdap version to `6.9.0-SNAPSHOT` due to security vulnerability fixes.
- Upgraded `slf4j.version` required by `logbackv1.2.11`.
- Remove `cdap.version` from `cdap-ldap-role` so that it inherits from parent.
- Updated `Authorizable` according to changed definition in `cdap` repo.
- Excluded `log4j:log4j` & `slf4j-log4j12` from `org.apache.ranger:ranger-plugins-common`.
- Added `log4j-over-slf4j` which works as a facade.

**Testing**
- Verified using `mvn dependency:tree`.
- Build successful using `mvn clean install`.