### PR TITLE
[CDAP-19316] Fix security vulnerabilities due to commons-collections

### DIFF
--- a/cdap-ranger/cdap-ranger-binding/pom.xml
+++ b/cdap-ranger/cdap-ranger-binding/pom.xml
@@ -68,7 +68,6 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
     </dependency>
     <!-- end of plugin-commons dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <cdap.version>6.9.0-SNAPSHOT</cdap.version>
+    <commons.collections.version>3.2.2</commons.collections.version>
     <slf4j.version>1.7.15</slf4j.version>
     <junit.version>4.11</junit.version>
     <surefire.redirectTestOutputToFile>true</surefire.redirectTestOutputToFile>
@@ -112,6 +113,11 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <version>${commons.collections.version}</version>
+      </dependency>
       <dependency>
         <groupId>io.cdap.cdap</groupId>
         <artifactId>cdap-security-spi</artifactId>


### PR DESCRIPTION
### Change Description

Fixed security vulnerabilities due to `commons-collections` dependency:
* [CVE-2015-7501](https://nvd.nist.gov/vuln/detail/CVE-2015-7501) 
* [CVE-2015-4852](https://nvd.nist.gov/vuln/detail/CVE-2015-4852)

Changes:
* Update the commons-collections dependency version to `3.2.2`. Other dependencies are transitively and directly dependent. The newer version is backward compatible.

### Verification
* Verified version override using `mvn dependency:tree`