### PR TITLE
CDAP-21027 : Upgrading hadoop version to 3.3.6 

### DIFF
--- a/cdap-ldap-role/pom.xml
+++ b/cdap-ldap-role/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <security.authorizer.class>io.cdap.cdap.security.authorization.ldap.role.LDAPRoleAccessController</security.authorizer.class>
-    <jackson.version>2.8.8</jackson.version>
+    <jackson.version>2.12.7</jackson.version>
     <maven.build.timestamp.format>HH:mm:ss dd-MM-yyyy</maven.build.timestamp.format>
   </properties>
 

--- a/cdap-ranger/cdap-ranger-binding/pom.xml
+++ b/cdap-ranger/cdap-ranger-binding/pom.xml
@@ -61,9 +61,8 @@
       <version>2.6</version>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-      <version>1.8.8</version>
+      <groupId>com.fasterxml.jackson.jaxrs</groupId>
+      <artifactId>jackson-jaxrs-json-provider</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-collections</groupId>
@@ -102,7 +101,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.5.0</version>
         <extensions>true</extensions>
         <configuration>
           <archive>

--- a/cdap-ranger/pom.xml
+++ b/cdap-ranger/pom.xml
@@ -69,7 +69,7 @@
 
 
   <properties>
-    <hadoop.version>2.3.0</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <ranger.version>0.7.0</ranger.version>
   </properties>
 
@@ -108,7 +108,20 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-jaxrs</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
+          </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-json-provider</artifactId>
+        <version>2.17.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.ranger</groupId>

--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/pom.xml
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>sentry-provider-db</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/cdap-sentry/cdap-sentry-extension/pom.xml
+++ b/cdap-sentry/cdap-sentry-extension/pom.xml
@@ -40,7 +40,7 @@
   <url>http://github.com/cdapio/cdap-security-extn/cdap-sentry</url>
 
   <properties>
-    <hadoop.version>2.3.0</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <sentry.version>1.7.0</sentry.version>
   </properties>
   
@@ -116,6 +116,29 @@
           <exclusion>
             <groupId>org.apache.sentry</groupId>
             <artifactId>sentry-core-model-sqoop</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-common</artifactId>
+        <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-core-asl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <modules>
     <module>cdap-ranger</module>
-    <module>cdap-sentry</module>
+<!-- TODO   <module>cdap-sentry</module> TO EVALUATE https://cdap.atlassian.net/browse/CDAP-21050 -->
     <module>cdap-security-extensions-dist</module>
     <module>cdap-ldap-role</module>
   </modules>
@@ -66,7 +66,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>6.9.1</cdap.version>
+    <cdap.version>6.11.0-SNAPSHOT</cdap.version>
     <commons.collections.version>3.2.2</commons.collections.version>
     <slf4j.version>1.7.15</slf4j.version>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
- Upgrading to Hadoop 3 
- This makes current cdap-sentry incompatible 
- apache Sentry is already retired since 2018 
- Removing Sentry module from compilation , but removed all vulnerability libs for safety . 
- https://cdap.atlassian.net/browse/CDAP-21050 , to be evaluated. 