### PR TITLE
[Security Vulnerability] CVE-2024-47561: Exclude org.apache.avro:avro

### DIFF
--- a/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/pom.xml
+++ b/cdap-sentry/cdap-sentry-extension/cdap-sentry-binding/pom.xml
@@ -58,6 +58,12 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.zookeeper</groupId>


### PR DESCRIPTION
context: [CVE-2024-47561](https://nvd.nist.gov/vuln/detail/CVE-2024-47561)